### PR TITLE
Hyperflex

### DIFF
--- a/playbooks/hyperflex_cluster_profiles.yml
+++ b/playbooks/hyperflex_cluster_profiles.yml
@@ -1,0 +1,166 @@
+---
+#
+# Configure HyperFlex Cluster Profiles
+#
+# The hosts group used is provided by the group variable or defaulted to 'Intersight_HX'.
+# You can specify a specific host (or host group) on the command line:
+#   ansible-playbook ... -e group=<your host group>
+#   e.g., ansible-playbook server_profiles.yml -e group=TME_Demo
+#
+- hosts: "{{ group | default('Intersight_HX') }}"
+  connection: local
+  gather_facts: false
+  vars:
+  # If your inventory or host/group_vars don't specify required api key information, you can set directly below:
+  # api_private_key: ~/Downloads/SecretKey.txt
+  # api_key_id: 5a3404ac3768393836093cab/5b02fa7e6d6c356772394170/5b02fad36d6c356772394449
+  vars_prompt:
+    
+    - name: "hx_vcenter_password"
+      prompt: "Enter the vCenter administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "hx_hypervisor_password"
+      prompt: "Enter the new ESXi nodes' administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "hx_dp_root_password"
+      prompt: "Enter the HyperFlex administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "execute_auto_support"
+      prompt: "Do you need to enable Auto Support settings? (yes/no)"
+      private: no
+
+    - name: "execute_proxy"
+      prompt: "Do you need to configure proxy settings? (yes/no)"
+      private: no
+
+    - name: "execute_iscsi"
+      prompt: "Do you need to configure additional vNICs for iSCSI settings? (yes/no)"
+      private: no
+
+    - name: "execute_fc"
+      prompt: "Do you need to configure additional vHBAs for FC settings? (yes/no)"
+      private: no
+
+  tasks:
+    # Cluster Profile
+    - import_role:
+        name: policies/hyperflex_policies/cluster_profile
+      vars:
+        hx_cluster_profile: "{{ hx_cluster_name }}"
+      tags: ['cluster_profile']
+    # Software Version 
+    - import_role:
+        name: policies/hyperflex_policies/software_version
+      vars:
+        hx_software_policy: "{{ hx_cluster_name }}-software-version-policy"
+      tags: ['software']
+    # DNS
+    - import_role:
+        name: policies/hyperflex_policies/sys_config
+      vars:
+        hx_sys_config_policy: "{{ hx_cluster_name }}-sys-config-policy"
+      tags: ['dns']
+    # Security
+    - import_role:
+        name: policies/hyperflex_policies/local_credential
+      vars:
+        hx_local_credential_policy: "{{ hx_cluster_name }}-local-credential-policy"
+      tags: ['security']
+    # vCenter
+    - import_role:
+        name: policies/hyperflex_policies/vcenter
+      vars:
+        hx_vcenter_config_policy: "{{ hx_cluster_name }}-vcenter-config-policy"
+      tags: ['vcenter']
+    # Storage Config
+    - import_role:
+        name: policies/hyperflex_policies/cluster_storage
+      vars:
+        hx_cluster_storage_policy: "{{ hx_cluster_name }}-cluster-storage-policy"
+      tags: ['storage']
+    # Auto Support
+    - import_role: 
+        name: policies/hyperflex_policies/auto_support
+      vars:
+        hx_auto_support_policy: "{{ hx_cluster_name }}-auto-support-policy"
+        hx_auto_support_enable: true
+      when: execute_auto_support|bool
+      tags: ['autosupport']
+    # Proxy
+    - import_role:
+        name: policies/hyperflex_policies/proxy
+      vars:
+        hx_proxy_setting_policy: "{{ hx_cluster_name }}-proxy-setting-policy"
+      when: execute_proxy|bool
+      tags: ['proxy']
+    # FC
+    - import_role:
+        name: policies/hyperflex_policies/fc
+      vars:
+        hx_fc_setting_policy: "{{ hx_cluster_name }}-ext-fc-storage-policy"
+        hx_fc_setting_enable: true
+      when: execute_fc|bool
+      tags: ['fc']
+    # iSCSI
+    - import_role:
+        name: policies/hyperflex_policies/iscsi
+      vars:
+        hx_iscsi_setting_policy: "{{ hx_cluster_name }}-ext-iscsi-storage-policy"
+        hx_iscsi_setting_enable: true
+      when: execute_iscsi|bool
+      tags: ['iscsi']
+    # Network Config
+    - import_role:
+        name: policies/hyperflex_policies/cluster_network
+      vars:
+        hx_cluster_network_policy: "{{ hx_cluster_name }}-cluster-network-policy"
+      tags: ['network']
+    # Node IP and Hostname
+    - import_role:
+        name: policies/hyperflex_policies/node_config
+      vars:
+        hx_node_config_policy: "{{ hx_cluster_name }}-node-config-policy"
+      tags: ['nodes']
+
+    - debug:
+        msg: "All policies and the HyperFlex cluster profile have been created."
+
+    - name: "Prompt to assign"
+      pause:
+        prompt: "Proceed with physical node assignment? (yes/no)"
+        echo: yes
+      register: assign_response
+      tags: ['prompt_assign']
+
+    # Assign servers to cluster profile and set deployment action
+    - include_role:
+        name: policies/hyperflex_policies/node_profiles
+      tags: ['assign']
+      when: assign_response.user_input|bool
+      # delegate_to: localhost
+      run_once: true
+
+    - name: "Prompt to deploy"
+      pause:
+        prompt: "Proceed with cluster deployment? (yes/no)"
+        echo: yes
+      register: deploy_response
+      tags: ['prompt_deploy']
+
+    # Set cluster profile deployment action
+    - include_role:
+        name: policies/hyperflex_policies/deploy
+      tags: ['deploy']
+      when: deploy_response.user_input|bool
+
+    - debug:
+        msg: "HyperFlex cluster creation is complete."

--- a/playbooks/hyperflex_edge_cluster_profiles.yml
+++ b/playbooks/hyperflex_edge_cluster_profiles.yml
@@ -1,0 +1,142 @@
+---
+#
+# Configure HyperFlex Edge Cluster Profiles
+#
+# The hosts group used is provided by the group variable or defaulted to 'Intersight_HX'.
+# You can specify a specific host (or host group) on the command line:
+#   ansible-playbook ... -e group=<your host group>
+#   e.g., ansible-playbook server_profiles.yml -e group=TME_Demo
+#
+- hosts: "{{ group | default('Intersight_HX') }}"
+  connection: local
+  gather_facts: false
+  vars:
+  # If your inventory or host/group_vars don't specify required api key information, you can set directly below:
+  # api_private_key: ~/Downloads/SecretKey.txt
+  # api_key_id: 5a3404ac3768393836093cab/5b02fa7e6d6c356772394170/5b02fad36d6c356772394449
+  vars_prompt:
+    
+    - name: "hx_vcenter_password"
+      prompt: "Enter the vCenter administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "hx_hypervisor_password"
+      prompt: "Enter the new ESXi nodes' administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "hx_dp_root_password"
+      prompt: "Enter the HyperFlex administrative password"
+      private: yes
+      confirm: yes
+      unsafe: yes
+
+    - name: "execute_auto_support"
+      prompt: "Do you need to enable Auto Support settings? (yes/no)"
+      private: no
+
+    - name: "execute_proxy"
+      prompt: "Do you need to configure proxy settings? (yes/no)"
+      private: no
+
+  tasks:
+    # Cluster Profile
+    - import_role:
+        name: policies/hyperflex_policies/edge_cluster_profile
+      vars:
+        hx_cluster_profile: "{{ hx_cluster_name }}"
+      tags: ['cluster_profile']
+    # Software Version 
+    - import_role:
+        name: policies/hyperflex_policies/edge_software_version
+      vars:
+        hx_software_policy: "{{ hx_cluster_name }}-software-version-policy"
+      tags: ['software']
+    # DNS
+    - import_role:
+        name: policies/hyperflex_policies/sys_config
+      vars:
+        hx_sys_config_policy: "{{ hx_cluster_name }}-sys-config-policy"
+      tags: ['dns']
+    # Security
+    - import_role:
+        name: policies/hyperflex_policies/local_credential
+      vars:
+        hx_local_credential_policy: "{{ hx_cluster_name }}-local-credential-policy"
+      tags: ['security']
+    # vCenter
+    - import_role:
+        name: policies/hyperflex_policies/vcenter
+      vars:
+        hx_vcenter_config_policy: "{{ hx_cluster_name }}-vcenter-config-policy"
+      tags: ['vcenter']
+    # Storage Config
+    - import_role:
+        name: policies/hyperflex_policies/edge_cluster_storage
+      vars:
+        hx_cluster_storage_policy: "{{ hx_cluster_name }}-cluster-storage-policy"
+      tags: ['storage']
+    # Auto Support
+    - import_role: 
+        name: policies/hyperflex_policies/auto_support
+      vars:
+        hx_auto_support_policy: "{{ hx_cluster_name }}-auto-support-policy"
+        hx_auto_support_enable: true
+      when: execute_auto_support|bool
+      tags: ['autosupport']
+    # Proxy
+    - import_role:
+        name: policies/hyperflex_policies/proxy
+      vars:
+        hx_proxy_setting_policy: "{{ hx_cluster_name }}-proxy-setting-policy"
+      when: execute_proxy|bool
+      tags: ['proxy']
+    # Network Config
+    - import_role:
+        name: policies/hyperflex_policies/edge_cluster_network
+      vars:
+        hx_cluster_network_policy: "{{ hx_cluster_name }}-cluster-network-policy"
+      tags: ['network']
+    # Node IP and Hostname
+    - import_role:
+        name: policies/hyperflex_policies/node_config
+      vars:
+        hx_node_config_policy: "{{ hx_cluster_name }}-node-config-policy"
+      tags: ['nodes']
+
+    - debug:
+        msg: "All policies and the HyperFlex cluster profile have been created."
+
+    - name: "Prompt to assign"
+      pause:
+        prompt: "Proceed with physical node assignment? (yes/no)"
+        echo: yes
+      register: assign_response
+      tags: ['prompt_assign']
+
+    # Assign servers to cluster profile and set deployment action
+    - include_role:
+        name: policies/hyperflex_policies/node_profiles
+      tags: ['assign']
+      when: assign_response.user_input|bool
+      # delegate_to: localhost
+      run_once: true
+
+    - name: "Prompt to deploy"
+      pause:
+        prompt: "Proceed with cluster deployment? (yes/no)"
+        echo: yes
+      register: deploy_response
+      tags: ['prompt_deploy']
+
+    # Set cluster profile deployment action
+    - include_role:
+        name: policies/hyperflex_policies/deploy
+      tags: ['deploy']
+      when: deploy_response.user_input|bool
+
+    - debug:
+        msg: "HyperFlex Edge cluster creation is complete."

--- a/playbooks/roles/policies/hyperflex_policies/auto_support/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/auto_support/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: "Configure {{ hx_auto_support_policy }} Auto Support Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/AutoSupportPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_auto_support_policy }}'"
+    api_body: {
+      "Name": "{{ hx_auto_support_policy }}",
+      "AdminState":"{{ hx_auto_support_enable }}",
+      "ServiceTicketReceipient":"{{ hx_auto_support_receipient }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: auto_support_policy
+
+- debug: msg="HyperFlex Autosupport Policy named {{ hx_auto_support_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/cluster_network/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_network/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: "Configure {{ hx_cluster_network_policy }} Cluster Network Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterNetworkPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_network_policy }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_network_policy }}",
+      "JumboFrame":"{{ hx_jumbo_frames }}",
+      "KvmIpRange":{
+        "StartAddr":"{{ ucs_kvm_start_ip }}",
+        "EndAddr":"{{ ucs_kvm_end_ip }}",
+        "Gateway":"{{ ucs_kvm_gateway }}",
+        "Netmask":"{{ ucs_kvm_netmask }}"
+      },
+      "MacPrefixRange":{
+        "StartAddr":"{{ hx_mac_start }}",
+        "EndAddr":"{{ hx_mac_end }}"
+      },
+      "MgmtVlan":{
+        "Name":"{{ hx_mgmt_vlan_name }}",
+        "VlanId":"{{ hx_mgmt_vlan_id }}"
+      },
+      "VmMigrationVlan":{
+        "Name":"{{ hx_migration_vlan_name }}",
+        "VlanId":"{{ hx_migration_vlan_id }}"
+      },
+      "VmNetworkVlans":"{{ hx_guest_vm_vlans }}",
+      "UplinkSpeed": "default",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: cluster_network
+
+- debug: msg="HyperFlex Cluster Network Policy named {{ hx_cluster_network_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/cluster_profile/defaults/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_profile/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Default variable values for HyperFlex Cluster Profiles 
+hx_mgmt_platform: FI
+hx_hypervisor_type: ESXi
+hx_replication_factor: 3
+hx_vdi_optimization: false
+hx_disk_cleanup: false
+hx_laz_autoconfig: false

--- a/playbooks/roles/policies/hyperflex_policies/cluster_profile/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_profile/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "Configure {{ hx_cluster_profile }} Cluster Profile"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_profile }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_profile }}",
+      "MgmtPlatform":"{{ hx_mgmt_platform }}",
+      "HypervisorType":"{{ hx_hypervisor_type }}",
+      "MgmtIpAddress":"{{ hx_mgmt_ip }}",
+      "MacAddressPrefix":"{{ hx_mgmt_mac_prefix }}",
+      "Replication":"{{ hx_replication_factor }}",
+      "StorageDataVlan":{
+        "Name":"{{ hx_data_vlan_name }}",
+        "VlanId":"{{ hx_data_vlan_id }}"
+      }
+    }
+  register: cluster_profile
+
+- debug: msg="HyperFlex Cluster Profile named {{ hx_cluster_profile }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/cluster_storage/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_storage/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: "Configure {{ hx_cluster_storage_policy }} Cluster Storage Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterStoragePolicies
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_storage_policy }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_storage_policy }}",
+      "VdiOptimization":"{{ hx_vdi_optimization }}",
+      "DiskPartitionCleanup":"{{ hx_disk_cleanup }}",
+      "LogicalAvalabilityZoneConfig":{
+        "AutoConfig":"{{ hx_laz_autoconfig }}"
+      },
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: storage_setting
+
+- debug: msg="HyperFlex Cluster Storage Policy named {{ hx_cluster_storage_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/deploy/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/deploy/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# Get cluster profile
+- name: Get Cluster Profile
+  vars:
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_name }}'"
+  register: profile
+# Prompt for cluster deployment action
+- name: "Prompt for deployment action"
+  pause:
+    prompt: "Set the deployment action. Valid choices are Validate, Deploy, Continue or Retry."
+    echo: yes
+  register: hx_action
+# Set cluster deployment action
+- name: Set Cluster Action
+  vars:
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_name }}'"
+    api_body: {
+      "Action": "{{ hx_action.user_input }}"
+    }
+  when:
+    - profile.api_response.ConfigContext.ConfigState != 'Configuring'
+    - profile.api_response.ConfigContext.ConfigState != 'Associated'
+# Can optionally wait for subsequent tasks if needed
+# register: result
+# until: result.api_response.config_context.config_state == 'Associated'
+# retries: 20
+# delay: 30
+- debug: msg="HyperFlex Cluster Profile deployment action has been triggered successfully."

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_network/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_network/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: "Configure {{ hx_cluster_network_policy }} Cluster Network Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterNetworkPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_network_policy }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_network_policy }}",
+      "JumboFrame":"{{ hx_jumbo_frames }}",
+      "MacPrefixRange":{
+        "StartAddr":"{{ hx_mac_start }}",
+        "EndAddr":"{{ hx_mac_end }}"
+      },
+      "MgmtVlan":{
+        "VlanId":"{{ hx_mgmt_vlan_id }}"
+      },
+      "UplinkSpeed":"{{ hx_uplink_speed }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: cluster_network
+
+- debug: msg="HyperFlex Cluster Network Policy named {{ hx_cluster_network_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/defaults/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Default variable values for HyperFlex Cluster Profiles 
+hx_mgmt_platform: EDGE
+hx_hypervisor_type: ESXi
+hx_vdi_optimization: false
+hx_disk_cleanup: false

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: "Configure {{ hx_cluster_profile }} Cluster Profile"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_profile }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_profile }}",
+      "MgmtPlatform":"{{ hx_mgmt_platform }}",
+      "HypervisorType":"{{ hx_hypervisor_type }}",
+      "MgmtIpAddress":"{{ hx_mgmt_ip }}",
+      "MacAddressPrefix":"{{ hx_mgmt_mac_prefix }}",
+      "StorageDataVlan":{
+        "VlanId":"{{ hx_data_vlan_id }}"
+      }
+    }
+  register: cluster_profile
+
+- debug: msg="HyperFlex Cluster Profile named {{ hx_cluster_profile }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_storage/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_storage/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: "Configure {{ hx_cluster_storage_policy }} Cluster Storage Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterStoragePolicies
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_storage_policy }}'"
+    api_body: {
+      "Name":"{{ hx_cluster_storage_policy }}",
+      "VdiOptimization":"{{ hx_vdi_optimization }}",
+      "DiskPartitionCleanup":"{{ hx_disk_cleanup }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: storage_setting
+
+- debug: msg="HyperFlex Cluster Storage Policy named {{ hx_cluster_storage_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/edge_software_version/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_software_version/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: "Configure {{ hx_software_policy }} Software Version Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/SoftwareVersionPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_software_policy }}'"
+    api_body: {
+      "Name":"{{ hx_software_policy }}",
+      "HxdpVersion":"{{ hxdp_version }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }  
+  register: software_policy
+
+- debug: msg="HyperFlex Software Version Policy named {{ hx_software_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/fc/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/fc/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: "Configure {{ hx_fc_setting_policy }} External FC Storage Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ExtFcStoragePolicies
+    query_params:
+      $filter: "Name eq '{{ hx_fc_setting_policy }}'"
+    api_body: {
+      "AdminState":"{{ hx_fc_setting_enable }}",
+      "Name":"{{ hx_fc_setting_policy }}",
+      "ExtaTraffic":{
+        "Name":"{{ hx_vsan_a_name }}",
+        "VsanId":"{{ hx_vsan_a_id }}"
+      },
+      "ExtbTraffic":{
+        "Name":"{{ hx_vsan_b_name }}",
+        "VsanId":"{{ hx_vsan_b_id }}"
+      },
+      "WwxnPrefixRange":{
+        "StartAddr":"{{ hx_fc_wwxn_range_start }}",
+        "EndAddr":"{{ hx_fc_wwxn_range_end }}"
+      },
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: fc_settings
+# Set WWXN prefix for the cluster profile when additional FC HBAs are configured
+- name: "Perform Action on {{ hx_profile_name }} Profile"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_name }}'"
+    api_body: {
+      "WwxnPrefix": "{{ hx_fc_wwxn_range_start }}"
+    }
+
+- debug: msg="HyperFlex External FC Storage Policy named {{ hx_fc_setting_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/iscsi/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/iscsi/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: "Configure {{ hx_iscsi_setting_policy }} External iSCSI Storage Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ExtIscsiStoragePolicies
+    query_params:
+      $filter: "Name eq '{{ hx_iscsi_setting_policy }}'"
+    api_body: {
+      "AdminState":"{{ hx_iscsi_setting_enable }}",
+      "Name":"{{ hx_iscsi_setting_policy }}",
+      "ExtaTraffic":{
+        "Name":"{{ hx_iscsi_vlan_a_name }}",
+        "VlanId":"{{ hx_iscsi_vlan_a_id }}"
+      },
+      "ExtbTraffic":{
+        "Name":"{{ hx_iscsi_vlan_b_name }}",
+        "VlanId":"{{ hx_iscsi_vlan_b_id }}"
+      },
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: iscsi_settings
+
+- debug: msg="HyperFlex External iSCSI Storage Policy named {{ hx_iscsi_setting_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/local_credential/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/local_credential/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "Configure {{ hx_local_credential_policy }} Local Credential Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/LocalCredentialPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_local_credential_policy }}'"
+    api_body: {
+      "Name": "{{ hx_local_credential_policy }}",
+      "HypervisorAdmin":"{{ hx_hypervisor_admin }}",
+      "FactoryHypervisorPassword":"{{ hx_hypervisor_factory_password }}",
+      "HypervisorAdminPwd":"{{ hx_hypervisor_password | default(omit) }}",
+      "HxdpRootPwd":"{{ hx_dp_root_password | default(omit) }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: local_credential
+
+- debug: msg="HyperFlex Local Credential Policy named {{ hx_local_credential_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/node_config/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/node_config/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: "Configure {{ hx_node_config_policy }} Node Configuration Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/NodeConfigPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_node_config_policy }}'"
+    api_body: {
+      "Name":"{{ hx_node_config_policy }}",
+      "NodeNamePrefix":"{{ hx_node_profile_prefix }}",
+      "MgmtIpRange":{
+        "StartAddr":"{{ esx_mgmt_ip_start }}",
+        "EndAddr":"{{ esx_mgmt_ip_end }}",
+        "Netmask":"{{ hx_mgmt_netmask }}",
+        "Gateway":"{{ hx_mgmt_gateway }}"
+      },
+      "HxdpIpRange":{
+        "StartAddr":"{{ hx_mgmt_vm_ip_start }}",
+        "EndAddr":"{{ hx_mgmt_vm_ip_end }}",
+        "Netmask":"{{ hx_mgmt_netmask }}",
+        "Gateway":"{{ hx_mgmt_gateway }}"
+      },
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: node_config
+
+- debug: msg="HyperFlex Node Configuration Policy named {{ hx_node_config_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/node_profiles/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/node_profiles/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# Get server Moids
+- name: Get server Moid
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_facts:
+    <<: *api_info
+    server_names:
+      - "{{ item }}"
+  loop: "{{ hx_servers }}"
+  register: inventory
+# Get Cluster Profile Attributes
+- name: "Get {{ hx_cluster_name }} HyperFlex Cluster Profile"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ClusterProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_cluster_name }}'"
+  register: profile
+# Assign servers and profile to node profile
+- name: "Configure Node Profile"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/NodeProfiles
+    query_params:
+      $filter: "Name eq '{{ hx_node_profile_prefix }}-{{ '%02d' % (idx + 1) }}'"
+    api_body: {
+      "Name":"{{ hx_node_profile_prefix }}-{{ '%02d' % (idx + 1) }}",
+      "AssignedServer": {
+        "Moid": "{{ item.intersight_servers[0].Moid }}"
+      },
+      "ClusterProfile": {
+        "Moid": "{{ profile.api_response.Moid }}"
+      }
+    }
+  when: item.intersight_servers is not none
+  loop: "{{ inventory.results }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.intersight_servers[0].Name }}"
+
+- debug: msg="HyperFlex Node Profiles have been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/proxy/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/proxy/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: "Configure {{ hx_proxy_setting_policy }} Proxy Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/ProxySettingPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_proxy_setting_policy }}'"
+    api_body: {
+      "Name":"{{ hx_proxy_setting_policy }}",
+      "Hostname":"{{ hx_proxy_setting_hostname }}",
+      "Port":"{{ hx_proxy_setting_port }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: proxy_setting
+
+- debug: msg="HyperFlex Proxy Policy named {{ hx_proxy_setting_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/software_version/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/software_version/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: "Configure {{ hx_software_policy }} Software Version Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/SoftwareVersionPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_software_policy }}'"
+    api_body: {
+      "Name":"{{ hx_software_policy }}",
+      "HxdpVersion":"{{ hxdp_version }}",
+      "ServerFirmwareVersion":"{{ ucs_firmware_version }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }  
+  register: software_policy
+
+- debug: msg="HyperFlex Software Version Policy named {{ hx_software_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/sys_config/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/sys_config/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "Configure {{ hx_sys_config_policy }} System Config Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/SysConfigPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_sys_config_policy }}'"
+    api_body: {
+      "Name": "{{ hx_sys_config_policy }}",
+      "Timezone":"{{ hx_sys_config_timezone }}",
+      "DnsServers":"{{ hx_sys_config_dns_servers }}",
+      "NtpServers":"{{ hx_sys_config_ntp_servers }}",
+      "DnsDomainName":"{{ hx_sys_config_dns_domain }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: sys_config
+
+- debug: msg="HyperFlex System Config Policy named {{ hx_sys_config_policy }} has been created successfully."

--- a/playbooks/roles/policies/hyperflex_policies/vcenter/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/vcenter/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "Configure {{ hx_vcenter_config_policy }} vCenter Config Policy"
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+  intersight_rest_api:
+    <<: *api_info
+    resource_path: /hyperflex/VcenterConfigPolicies
+    query_params:
+      $filter: "Name eq '{{ hx_vcenter_config_policy }}'"
+    api_body: {
+      "Name":"{{ hx_vcenter_config_policy }}",
+      "Hostname":"{{ hx_vcenter_hostname }}",
+      "Username":"{{ hx_vcenter_username }}",
+      "Password":"{{ hx_vcenter_password | default(omit) }}",
+      "DataCenter":"{{ hx_vcenter_datacenter }}",
+      "ClusterProfiles": [
+        {
+        "Moid": "{{ cluster_profile.api_response.Moid }}"
+        }
+      ]
+    }
+  register: vcenter
+
+- debug: msg="HyperFlex vCenter Config Policy named {{ hx_vcenter_config_policy }} has been created successfully."

--- a/playbooks/update_hx_edge_inventory.yml
+++ b/playbooks/update_hx_edge_inventory.yml
@@ -1,0 +1,61 @@
+---
+#
+# Summary: Auto generate (or update) the Ansible inventory file with all servers (Name and Moid or each discovered server)
+#
+# The hosts group used is provided by the group variable or defaulted to 'Intersight'.
+# You can specify a specific host (or host group) on the command line:
+#   ansible-playbook ... -e group=<your host group>
+#   e.g., ansible-playbook server_profiles.yml -e group=TME_Demo
+#
+# This playbook only runs once (and not for each server in the inventory), but the hosts group is used to get API key info
+#
+- hosts: "{{ group | default('Intersight') }}"
+  connection: local
+  gather_facts: false
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+    # Change filepath if you want to update a different inventory file
+    filepath: "{{ inventory_file }}"
+    # Change host_group if you want to use another group name for your servers in the created inventory
+    host_group: Intersight_Servers
+  tasks:
+    # Enclose tasks in a block that is only run once
+    - block:
+        # Find all servers
+        - intersight_facts:
+            <<: *api_info
+            server_names:
+          register: all_results
+        # Place the servers in a group in the file
+        - debug:
+            msg: Inventory filepath "{{ filepath }}"
+        - lineinfile:
+            path: "{{ filepath }}"
+            line: "[{{ host_group }}]"
+            create: true
+        # Update servers in the file
+        - lineinfile:
+            path: "{{ filepath }}"
+            insertafter: "^\\[{{ host_group }}\\]"
+            regexp: "^{{ item.Name }} serial={{ item.Serial }} "
+            # Each line of the inventory has the following:
+            # Name server_moid=<Moid value> model=<Model value> boot_policy=<policy from tag> | 'na'
+            line: "{{ item.Name }} serial={{ item.Serial }} server_moid={{ item.Moid }} model={{ item.Model }}"
+            create: true
+          # Ansible and jmespath contains have type differences, so to/from_json used
+          loop: "{{ all_results.intersight_servers | json_query(platform_query) | to_json | from_json | json_query(model_query) }}"
+          loop_control:
+            label: "{{ item.Name }}"
+          vars:
+            # Filter for IMC and C-Series only (no HX)
+            platform_query: "[?PlatformType=='IMC']"
+            model_query: "[?contains(Model, 'HX')]"
+          when: all_results.intersight_servers is defined
+      delegate_to: localhost
+      run_once: true

--- a/playbooks/update_hx_inventory.yml
+++ b/playbooks/update_hx_inventory.yml
@@ -1,0 +1,61 @@
+---
+#
+# Summary: Auto generate (or update) the Ansible inventory file with all servers (Name and Moid or each discovered server)
+#
+# The hosts group used is provided by the group variable or defaulted to 'Intersight'.
+# You can specify a specific host (or host group) on the command line:
+#   ansible-playbook ... -e group=<your host group>
+#   e.g., ansible-playbook server_profiles.yml -e group=TME_Demo
+#
+# This playbook only runs once (and not for each server in the inventory), but the hosts group is used to get API key info
+#
+- hosts: "{{ group | default('Intersight') }}"
+  connection: local
+  gather_facts: false
+  vars:
+    # Create an anchor for api_info that can be used throughout the file
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      state: "{{ state | default(omit) }}"
+    # Change filepath if you want to update a different inventory file
+    filepath: "{{ inventory_file }}"
+    # Change host_group if you want to use another group name for your servers in the created inventory
+    host_group: Intersight_Servers
+  tasks:
+    # Enclose tasks in a block that is only run once
+    - block:
+        # Find all servers
+        - intersight_facts:
+            <<: *api_info
+            server_names:
+          register: all_results
+        # Place the servers in a group in the file
+        - debug:
+            msg: Inventory filepath "{{ filepath }}"
+        - lineinfile:
+            path: "{{ filepath }}"
+            line: "[{{ host_group }}]"
+            create: true
+        # Update servers in the file
+        - lineinfile:
+            path: "{{ filepath }}"
+            insertafter: "^\\[{{ host_group }}\\]"
+            regexp: "^{{ item.Name }} serial={{ item.Serial }} "
+            # Each line of the inventory has the following:
+            # Name server_moid=<Moid value> model=<Model value> boot_policy=<policy from tag> | 'na'
+            line: "{{ item.Name }} serial={{ item.Serial }} server_moid={{ item.Moid }} model={{ item.Model }}"
+            create: true
+          # Ansible and jmespath contains have type differences, so to/from_json used
+          loop: "{{ all_results.intersight_servers | json_query(platform_query) | to_json | from_json | json_query(model_query) }}"
+          loop_control:
+            label: "{{ item.Name }}"
+          vars:
+            # Filter for IMC and C-Series only (no HX)
+            platform_query: "[?PlatformType=='UCSFI']"
+            model_query: "[?contains(Model, 'HX')]"
+          when: all_results.intersight_servers is defined
+      delegate_to: localhost
+      run_once: true


### PR DESCRIPTION
Commits includes the following... 
Four new playbooks:
Two for scanning Intersight for HX model servers, one each for UCSM managed servers and one for standalone (Edge) servers.
Two for creating the HX cluster profiles, which create the policies, assign the physical servers, and starts the deployment, one for Edge and one for FI connected clusters due to differences in the variables needed.
All the imported and included roles needed to perform the plays.
To make the playbooks work, a host_vars file for each cluster would need to be created with all of the variable values required for the cluster profile creation. An example of the complete process can be added to the readme if desired, but will also be outlined in the accompanying published white paper, and also in a planned video demo.