### PR TITLE
Fixed multiple cluster deployment errors and task names

### DIFF
--- a/playbooks/hyperflex_cluster_profiles.yml
+++ b/playbooks/hyperflex_cluster_profiles.yml
@@ -139,25 +139,25 @@
         prompt: "Proceed with physical node assignment? (yes/no)"
         echo: yes
       register: assign_response
+      run_once: true
       tags: ['prompt_assign']
 
     # Assign servers to cluster profile and set deployment action
-    - include_role:
+    - import_role:
         name: policies/hyperflex_policies/node_profiles
       tags: ['assign']
       when: assign_response.user_input|bool
-      # delegate_to: localhost
-      run_once: true
 
     - name: "Prompt to deploy"
       pause:
         prompt: "Proceed with cluster deployment? (yes/no)"
         echo: yes
       register: deploy_response
+      run_once: true
       tags: ['prompt_deploy']
 
     # Set cluster profile deployment action
-    - include_role:
+    - import_role:
         name: policies/hyperflex_policies/deploy
       tags: ['deploy']
       when: deploy_response.user_input|bool

--- a/playbooks/hyperflex_edge_cluster_profiles.yml
+++ b/playbooks/hyperflex_edge_cluster_profiles.yml
@@ -115,25 +115,25 @@
         prompt: "Proceed with physical node assignment? (yes/no)"
         echo: yes
       register: assign_response
+      run_once: true
       tags: ['prompt_assign']
 
     # Assign servers to cluster profile and set deployment action
-    - include_role:
+    - import_role:
         name: policies/hyperflex_policies/node_profiles
       tags: ['assign']
       when: assign_response.user_input|bool
-      # delegate_to: localhost
-      run_once: true
 
     - name: "Prompt to deploy"
       pause:
         prompt: "Proceed with cluster deployment? (yes/no)"
         echo: yes
       register: deploy_response
+      run_once: true
       tags: ['prompt_deploy']
 
     # Set cluster profile deployment action
-    - include_role:
+    - import_role:
         name: policies/hyperflex_policies/deploy
       tags: ['deploy']
       when: deploy_response.user_input|bool

--- a/playbooks/roles/policies/hyperflex_policies/auto_support/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/auto_support/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_auto_support_policy }} Auto Support Policy"
+- name: "Configure Auto Support Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/cluster_network/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_network/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_network_policy }} Cluster Network Policy"
+- name: "Configure Cluster Network Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/cluster_profile/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_profile/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_profile }} Cluster Profile"
+- name: "Configure Cluster Profile"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/cluster_storage/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/cluster_storage/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_storage_policy }} Cluster Storage Policy"
+- name: "Configure Cluster Storage Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/deploy/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/deploy/tasks/main.yml
@@ -20,6 +20,7 @@
     prompt: "Set the deployment action. Valid choices are Validate, Deploy, Continue or Retry."
     echo: yes
   register: hx_action
+  run_once: true
 # Set cluster deployment action
 - name: Set Cluster Action
   vars:

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_network/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_network/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_network_policy }} Cluster Network Policy"
+- name: "Configure Cluster Network Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_profile/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_profile }} Cluster Profile"
+- name: "Configure Cluster Profile"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/edge_cluster_storage/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_cluster_storage/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_cluster_storage_policy }} Cluster Storage Policy"
+- name: "Configure Cluster Storage Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/edge_software_version/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/edge_software_version/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_software_policy }} Software Version Policy"
+- name: "Configure Software Version Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/fc/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/fc/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_fc_setting_policy }} External FC Storage Policy"
+- name: "Configure External FC Storage Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/iscsi/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/iscsi/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_iscsi_setting_policy }} External iSCSI Storage Policy"
+- name: "Configure External iSCSI Storage Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/local_credential/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/local_credential/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_local_credential_policy }} Local Credential Policy"
+- name: "Configure Local Credential Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/node_config/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/node_config/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_node_config_policy }} Node Configuration Policy"
+- name: "Configure Node Configuration Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/node_profiles/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/node_profiles/tasks/main.yml
@@ -16,7 +16,7 @@
   loop: "{{ hx_servers }}"
   register: inventory
 # Get Cluster Profile Attributes
-- name: "Get {{ hx_cluster_name }} HyperFlex Cluster Profile"
+- name: "Get HyperFlex Cluster Profile"
   intersight_rest_api:
     <<: *api_info
     resource_path: /hyperflex/ClusterProfiles

--- a/playbooks/roles/policies/hyperflex_policies/proxy/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/proxy/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_proxy_setting_policy }} Proxy Policy"
+- name: "Configure Proxy Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/software_version/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/software_version/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_software_policy }} Software Version Policy"
+- name: "Configure Software Version Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/sys_config/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/sys_config/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_sys_config_policy }} System Config Policy"
+- name: "Configure System Config Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info

--- a/playbooks/roles/policies/hyperflex_policies/vcenter/tasks/main.yml
+++ b/playbooks/roles/policies/hyperflex_policies/vcenter/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure {{ hx_vcenter_config_policy }} vCenter Config Policy"
+- name: "Configure vCenter Config Policy"
   vars:
     # Create an anchor for api_info that can be used throughout the file
     api_info: &api_info


### PR DESCRIPTION
Fixed errors when deploying multiple clusters at once, and removed the names of the clusters from the task names to avoid possible confusion regarding what the plays were doing at that time.