### PR TITLE
Fix typo in boot_order_policy docs

### DIFF
--- a/plugins/modules/intersight_boot_order_policy.py
+++ b/plugins/modules/intersight_boot_order_policy.py
@@ -112,7 +112,7 @@ options:
         description:
           - The IP Address family type to use during the PXE Boot process.
           - Option is used when device_type is pxe.
-        chocies: [None, IPv4, IPv6]
+        choices: [None, IPv4, IPv6]
         default: None
       interface_source:
         description:


### PR DESCRIPTION
docs.ansible.com shows an error because of that typo: https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_boot_order_policy_module.html#ansible-collections-cisco-intersight-intersight-boot-order-policy-module