### PR TITLE
Add stable-ci branch for CI preparations

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,7 +2,13 @@
 name: Ansible-test CI
 on:
   workflow_dispatch:
-
+  push:
+    branches:
+      - stable-ci
+  pull_request_target:
+    branches:
+      - main
+      - 'stable-*'
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
@@ -24,9 +30,9 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.16
-          - stable-2.17
-          - stable-2.18
+          # - stable-2.16
+          # - stable-2.17
+          # - stable-2.18
           - stable-2.19
     steps:
       - name: Checkout repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ on:
   push:
     branches:
       - main
+      - 'stable-*'
   pull_request:
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still

--- a/tests/integration/targets/intersight_mac_pool/defaults/main.yml
+++ b/tests/integration/targets/intersight_mac_pool/defaults/main.yml
@@ -1,2 +1,3 @@
-api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID') }}"
-api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY') }}"
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_mac_pool/tasks/tests.yml
+++ b/tests/integration/targets/intersight_mac_pool/tasks/tests.yml
@@ -12,12 +12,14 @@
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
       state: absent
 
   - name: Create mac pool - check-mode
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
       description: "Test mac pool description"
       tags: [
         {
@@ -46,6 +48,7 @@
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
       description: "Test mac pool description"
       tags: [
         {
@@ -67,6 +70,7 @@
     cisco.intersight.intersight_mac_pool_info:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
     register: creation_info_res
 
   - name: Verify mac pool creation by info
@@ -88,6 +92,7 @@
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
       description: "Test mac pool description"
       tags: [
         {
@@ -132,6 +137,7 @@
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool_2
+      organization: "{{ organization }}"
       description: "Test mac pool description"
       tags: [
         {
@@ -152,7 +158,8 @@
   - name: Fetch all mac pools under default organization
     cisco.intersight.intersight_mac_pool_info:
       <<: *api_info
-      organization: default
+      # organization: default
+      organization: "{{ organization }}"
     register: creation_info_res_b
 
   - name: Check that there are at least 2 mac pools under this organization
@@ -165,10 +172,12 @@
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool
+      organization: "{{ organization }}"
       state: absent
 
   - name: Remove mac pool 2
     cisco.intersight.intersight_mac_pool:
       <<: *api_info
       name: test_mac_pool_2
+      organization: "{{ organization }}"
       state: absent

--- a/tests/integration/targets/prepare_test_run/generate_integration_config.sh
+++ b/tests/integration/targets/prepare_test_run/generate_integration_config.sh
@@ -1,27 +1,20 @@
 #!/usr/bin/env bash
+# This script creates a private key PEM file and integration_config.yml with vars to include for ansible_test run
+set -e
 
-# This script creates a file for the private key, substitutes its relative path
-# into the template file, and creates the final configuration file.
+# Define file paths relative to workspace
+readonly TEMPLATE_FILE="./tests/integration/targets/prepare_test_run/integration_config.yml.tpl"
+readonly OUTPUT_FILE="./tests/integration/targets/prepare_test_run/integration_config.yml"
+readonly PRIVATE_KEY_FILE="./tests/integration/targets/prepare_test_run/api_private_key.pem"
 
-set -e # Exit immediately if a command exits with a non-zero status.
-
-# Define file paths relative to the collection root
-readonly TEMPLATE_FILE="./integration_config.yml.tpl"
-readonly OUTPUT_FILE="./integration_config.yml"
-readonly PRIVATE_KEY_FILE="./api_private_key.pem"
-
-# 1. Write the private key from the environment variable to its own file.
-echo "${API_KEY_ID}" > "$PRIVATE_KEY_FILE"
+echo "${API_PRIVATE_KEY}" > "$PRIVATE_KEY_FILE"
 echo "Private key written to ${PRIVATE_KEY_FILE}"
 
-# 2. Export the relative path to the key file for envsubst.
-# Since the output config and the key file are in the same directory,
-# the relative path is just the filename.
-API_PRIVATE_KEY_PATH="./$(basename "$PRIVATE_KEY_FILE")"
+# Export the relative path to the key file for envsubst.
+API_PRIVATE_KEY_PATH="./targets/prepare_test_run/api_private_key.pem" 
 export API_PRIVATE_KEY_PATH
 
-# 3. Use envsubst to replace only the specified variables in the template.
-# This prevents other text with '$' from being accidentally substituted.
+# Use envsubst to replace only the specified variables in the template.
 # shellcheck disable=SC2016
 envsubst '${API_PRIVATE_KEY_PATH},${API_KEY_ID}' < "$TEMPLATE_FILE" > "$OUTPUT_FILE"
 


### PR DESCRIPTION
#### Merge stable-ci into main

- Use new INTERSIGHT_API_KEY_ID_CI key 
- Use new INTERSIGHT_API_PRIVATE_KEY_CI key
- Add stable-* branch to tests trigger for CI modifications
- Set correct PATH for scripts and key files
- Temp: Add organization to intersight_mac_pool integration tests until organization "default" will be set on the environment
- Temp: Disable test concurrency - run on stable-2.19 until the integration tests will be designed to run in parallel

