### PR TITLE
Create modules to manage thermal policy

### DIFF
--- a/plugins/modules/intersight_thermal_policy.py
+++ b/plugins/modules/intersight_thermal_policy.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_thermal_policy
+short_description: Thermal Policy configuration for Cisco Intersight
+description:
+  - Manages Thermal Policy configuration on Cisco Intersight.
+  - A policy to configure the fan control mode on Cisco Intersight managed servers.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/thermal/Policy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles, Policies, and Pools that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Thermal Policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Thermal Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  fan_control_mode:
+    description:
+      - Sets the fan control mode for the policy.
+      - This determines how fan speed is managed to balance cooling, power consumption, and acoustics.
+    type: str
+    choices: ['Balanced', 'LowPower', 'HighPower', 'MaximumPower', 'Acoustic']
+    default: 'Balanced'
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create a Thermal Policy with High Power fan mode
+  cisco.intersight.intersight_thermal_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "HighPower-Thermal-Policy"
+    description: "High power thermal policy"
+    tags:
+      - Key: "Site"
+        Value: "DataCenter-A"
+    fan_control_mode: "HighPower"
+    state: present
+
+- name: Create a Thermal Policy using the default Balanced fan mode
+  cisco.intersight.intersight_thermal_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "Balanced-Power-Policy"
+    description: "A standard thermal policy for general use."
+    state: present
+
+- name: Delete a Thermal Policy
+  cisco.intersight.intersight_thermal_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "HighPower-Thermal-Policy"
+    state: absent
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "test_thermal_policy",
+        "ObjectType": "thermal.Policy",
+        "FanControlMode": "LowPower",
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "tag1"
+            },
+            {
+                "Key": "Site2",
+                "Value": "tag2"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        fan_control_mode=dict(
+            type='str',
+            choices=['Balanced', 'LowPower', 'HighPower', 'MaximumPower', 'Acoustic'],
+            default='Balanced'
+        )
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    #
+    # Argument spec above, resource path, and API body should be the only code changed in each policy module
+    #
+    # Resource path used to configure policy
+    resource_path = '/thermal/Policies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name'],
+        'Tags': intersight.module.params['tags'],
+        'FanControlMode': intersight.module.params['fan_control_mode']
+    }
+    # Passing an empty description to this API will result with 400 HTTP error.
+    if intersight.module.params['description']:
+        intersight.api_body['Description'] = intersight.module.params['description']
+
+    #
+    # Code below should be common across all policy modules
+    #
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_thermal_policy_info.py
+++ b/plugins/modules/intersight_thermal_policy_info.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_thermal_policy_info
+short_description: Gather information about Thermal Policies in Cisco Intersight
+description:
+  - Gather information about Thermal Policies in L(Cisco Intersight,https://intersight.com).
+  - Information can be filtered by O(organization) and O(name).
+  - If no filters are passed, all Thermal Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization the Thermal Policy belongs to.
+    type: str
+  name:
+    description:
+      - The name of the Thermal Policy to gather information from.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Fetch a specific Thermal Policy by name
+  cisco.intersight.intersight_thermal_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "HighPower-Thermal-Policy"
+
+- name: Fetch all Thermal Policies in a specific Organization
+  cisco.intersight.intersight_thermal_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+
+- name: Fetch all Thermal Policies
+  cisco.intersight.intersight_thermal_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": [
+    {
+        "Name": "thermal_policy_1",
+        "ObjectType": "thermal.Policy",
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "tag1"
+            },
+            {
+                "Key": "Site2",
+                "Value": "tag2"
+            }
+        ]
+    },
+    {
+        "Name": "thermal_policy_2",
+        "ObjectType": "thermal.Policy",
+        "Tags": [
+            {
+                "Key": "Site1",
+                "Value": "tag1"
+            },
+            {
+                "Key": "Site2",
+                "Value": "tag2"
+            }
+        ]
+    }
+  ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Resource path used to fetch info
+    resource_path = '/thermal/Policies'
+
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_thermal_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_thermal_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_thermal_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_thermal_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_thermal_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_thermal_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml

--- a/tests/integration/targets/intersight_thermal_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_thermal_policy/tasks/tests.yml
@@ -1,0 +1,147 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      state: absent
+
+  - name: Create thermal policy - check-mode
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      description: "Test thermal policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+      fan_control_mode: "LowPower"
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify thermal policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response == {}
+
+  - name: Create thermal policy
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      description: "Test thermal policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+      fan_control_mode: "LowPower"
+    register: creation_res
+
+  - name: Fetch info after creation
+    cisco.intersight.intersight_thermal_policy_info:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+    register: creation_info_res
+
+  - name: Verify thermal policy creation by info
+    ansible.builtin.assert:
+      that:
+        - creation_res.changed
+        - creation_info_res.api_response[0].Name == 'test_thermal_policy'
+        - creation_info_res.api_response[0].FanControlMode == 'LowPower'
+
+  - name: Verify thermal policy creation response aligns with info response
+    ansible.builtin.assert:
+      that:
+        - creation_res.api_response.Name == creation_info_res.api_response[0].Name
+        - creation_res.api_response.FanControlMode == creation_info_res.api_response[0].FanControlMode
+
+  - name: Create thermal policy (idempotency check)
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      description: "Test thermal policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+      fan_control_mode: "LowPower"
+    register: creation_res_ide
+
+  - name: Verify thermal policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not creation_res_ide.changed
+
+  - name: Change fan control mode to an existing thermal policy
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      fan_control_mode: "HighPower"
+    register: changed_res
+
+  - name: Fetch info after change
+    cisco.intersight.intersight_thermal_policy_info:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+    register: change_info_res
+
+  - name: Verify thermal policy change by info
+    ansible.builtin.assert:
+      that:
+        - changed_res.changed
+        - change_info_res.api_response[0].Name == 'test_thermal_policy'
+        - change_info_res.api_response[0].FanControlMode == 'HighPower'
+
+  - name: Create another thermal policy
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy_2
+      organization: "{{ organization }}"
+      description: "Test another thermal policy description"
+      fan_control_mode: "Balanced"
+    register: creation_res_b
+
+  - name: Fetch all thermal policies under selected organization
+    cisco.intersight.intersight_thermal_policy_info:
+      <<: *api_info
+      organization: "{{ organization }}"
+    register: creation_info_res_b
+
+  - name: Check that there are at least thermal policies under this organization
+    ansible.builtin.assert:
+      that:
+        - creation_info_res_b.api_response | length > 1
+
+  always:
+  - name: Remove thermal policy 1
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy
+      organization: "{{ organization }}"
+      state: absent
+
+  - name: Remove thermal policy 2
+    cisco.intersight.intersight_thermal_policy:
+      <<: *api_info
+      name: test_thermal_policy_2
+      organization: "{{ organization }}"
+      state: absent


### PR DESCRIPTION
#### SUMMARY
- Create thermal policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_thermal_policy.py
- plugins/modules/intersight_thermal_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests