### PR TITLE
Create vlan policy module

### DIFF
--- a/plugins/modules/intersight_vlan_policy.py
+++ b/plugins/modules/intersight_vlan_policy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_vlan_policy
+short_description: Manage VLAN Policies and VLANs for Cisco Intersight
+description:
+  - Create, update, and delete VLAN Policies on Cisco Intersight.
+  - Manage individual VLANs within VLAN policies.
+  - Supports both regular VLANs and Private VLANs (Primary, Isolated, Community) configurations.
+  - VLAN policies define network segmentation and can be attached to LAN Connectivity policies and Server Profiles.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/fabric/EthNetworkPolicy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the VLAN Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the VLAN Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  vlans:
+    description:
+      - List of VLANs to be created and attached to the VLAN policy.
+      - Each VLAN will be named as C(prefix_vlan_id) (e.g., prod_100).
+      - Leave empty to create a policy without VLANs for manual configuration later.
+    type: list
+    elements: dict
+    suboptions:
+      prefix:
+        description:
+          - Prefix for the VLAN name.
+          - Combined with vlan_id to create the full VLAN name (prefix_vlan_id).
+        type: str
+        required: true
+      vlan_id:
+        description:
+          - Enter a valid VLAN ID or ID range between 2 and 4093. You can enter a range of IDs using a hyphen,
+            and you can enter multiple IDs or ID ranges separated by commas.
+          - Examples of valid VLAN IDs or ID ranges are 50, 200, 2000-2100.
+            You cannot use VLANs from 4043-4047, 4094, and 4095 because these IDs are reserved for system use.
+          - You can create a maximum of 3000 VLANs at a time.
+          - VLAN ID number (1-4094).
+          - Must be unique within the fabric interconnect domain.
+        type: int
+        required: true
+      is_native:
+        description:
+          - Whether this VLAN is the native VLAN for the fabric interconnect domain.
+        type: bool
+        default: false
+      auto_allow_on_uplinks:
+        description:
+          - Whether to automatically allow this VLAN on uplinks.
+        type: bool
+        default: true
+      enable_sharing:
+        description:
+          - When selected, enables Private VLAN sharing options.
+        type: bool
+        default: false
+      multicast_policy_name:
+        description:
+          - Name of the multicast policy to associate with this VLAN.
+          - Required when enable_sharing is false.
+        type: str
+      sharing_type:
+        description:
+          - Type of VLAN sharing when enable_sharing is true.
+        type: str
+        choices: ['Primary', 'Isolated', 'Community']
+      primary_vlan_id:
+        description:
+          - The Primary VLAN ID of the VLAN, if the sharing type of the VLAN is Isolated or Community.
+        type: int
+      state:
+        description:
+          - Whether to create/update or delete the VLAN.
+        type: str
+        choices: ['present', 'absent']
+        default: present
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create a VLAN Policy with multiple VLANs
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "datacenter-vlan-policy"
+    description: "VLAN policy for datacenter infrastructure"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+      - Key: "Site"
+        Value: "DataCenter-A"
+    vlans:
+      - prefix: "prod"
+        vlan_id: 100
+        auto_allow_on_uplinks: true
+        enable_sharing: false
+        multicast_policy_name: "default-multicast-policy"
+      - prefix: "dev"
+        vlan_id: 200
+        auto_allow_on_uplinks: false
+        enable_sharing: false
+        multicast_policy_name: "default-multicast-policy"
+      - prefix: "mgmt"
+        vlan_id: 300
+        auto_allow_on_uplinks: true
+        enable_sharing: false
+        multicast_policy_name: "default-multicast-policy"
+        is_native: true
+    state: present
+
+- name: Create a VLAN Policy with VLAN sharing (Private VLANs)
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "private-vlan-policy"
+    description: "Policy with private VLAN configuration"
+    vlans:
+      - prefix: "primary"
+        vlan_id: 79
+        enable_sharing: true
+        sharing_type: "Primary"
+        auto_allow_on_uplinks: true
+      - prefix: "isolated"
+        vlan_id: 90
+        enable_sharing: true
+        sharing_type: "Isolated"
+        primary_vlan_id: 79
+        auto_allow_on_uplinks: true
+      - prefix: "community"
+        vlan_id: 91
+        enable_sharing: true
+        sharing_type: "Community"
+        primary_vlan_id: 79
+        auto_allow_on_uplinks: true
+    state: present
+
+- name: Create a VLAN Policy with mixed configurations
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+    name: "mixed-vlan-policy"
+    description: "Mixed configuration with shared and non-shared VLANs"
+    vlans:
+      - prefix: "web"
+        vlan_id: 10
+        auto_allow_on_uplinks: true
+        enable_sharing: false
+        multicast_policy_name: "web-multicast-policy"
+      - prefix: "db"
+        vlan_id: 20
+        auto_allow_on_uplinks: false
+        enable_sharing: false
+        state: absent
+        multicast_policy_name: "db-multicast-policy"
+      - prefix: "dmz_primary"
+        vlan_id: 50
+        enable_sharing: true
+        sharing_type: "Primary"
+        auto_allow_on_uplinks: true
+        state: present
+      - prefix: "dmz_isolated"
+        vlan_id: 51
+        enable_sharing: true
+        sharing_type: "Isolated"
+        primary_vlan_id: 50
+        auto_allow_on_uplinks: true
+    state: present
+
+- name: Create a VLAN Policy with minimal configuration (policy only)
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "empty-vlan-policy"
+    description: "Empty policy for manual VLAN configuration"
+    state: present
+
+- name: Update an existing VLAN Policy
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "datacenter-vlan-policy"
+    description: "Updated description for datacenter infrastructure"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+      - Key: "Site"
+        Value: "DataCenter-A"
+      - Key: "Updated"
+        Value: "2024-01-01"
+    state: present
+
+- name: Delete a VLAN Policy
+  cisco.intersight.intersight_vlan_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "datacenter-vlan-policy"
+    state: absent
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "test_vlan_policy",
+        "ObjectType": "fabric.EthNetworkPolicy",
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "DataCenter-A"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def save_changed_state_and_reset(intersight, changed_states):
+    """
+    Save the current changed state to the list and reset it for the next operation.
+    Args:
+        intersight: IntersightModule instance
+        changed_states: List of changed states
+    """
+    changed_states.append(intersight.result['changed'])
+    intersight.result['changed'] = False
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        vlans=dict(type='list', elements='dict', options=dict(
+            prefix=dict(type='str', required=True),
+            vlan_id=dict(type='int', required=True),
+            auto_allow_on_uplinks=dict(type='bool', default=True),
+            enable_sharing=dict(type='bool', default=False),
+            multicast_policy_name=dict(type='str'),
+            sharing_type=dict(type='str', choices=['Primary', 'Isolated', 'Community']),
+            primary_vlan_id=dict(type='int'),
+            is_native=dict(type='bool', default=False),
+            state=dict(type='str', choices=['present', 'absent'], default='present')
+        ))
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    # Initialize structured response
+    final_response = {
+        'vlan_policy': {},
+        'vlans': []
+    }
+    intersight.result['api_response'] = final_response
+    intersight.result['trace_id'] = ''
+
+    # Initialize list to track changed states from each API call
+    changed_states = []
+
+    # Resource path used to configure policy
+    resource_path = '/fabric/EthNetworkPolicies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+    if intersight.module.params['state'] == 'present':
+        if intersight.module.params['description']:
+            intersight.api_body['Description'] = intersight.module.params['description']
+
+        if intersight.module.params['tags']:
+            intersight.api_body['Tags'] = intersight.module.params['tags']
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    # Store the VLAN policy response
+    final_response['vlan_policy'] = intersight.result['api_response']
+
+    # Save the changed state and reset for next operation
+    save_changed_state_and_reset(intersight, changed_states)
+
+    vlan_policy_moid = None
+    if intersight.module.params['state'] == 'present' and final_response['vlan_policy']:
+        vlan_policy_moid = final_response['vlan_policy']['Moid']
+
+    # Process VLANs if provided
+    if intersight.module.params['state'] == 'present' and intersight.module.params['vlans']:
+        # Cache for multicast policy MOIDs to avoid redundant API calls
+        multicast_policy_cache = {}
+
+        for vlan_config in intersight.module.params['vlans']:
+            # Validate VLAN configuration
+            prefix = vlan_config['prefix']
+            vlan_id = vlan_config['vlan_id']
+            auto_allow_on_uplinks = vlan_config.get('auto_allow_on_uplinks')
+            enable_sharing = vlan_config.get('enable_sharing')
+            is_native = vlan_config.get('is_native')
+
+            # Generate VLAN name: prefix_vlan_id
+            vlan_name = f"{prefix}_{vlan_id}"
+
+            # Build base VLAN API body
+            vlan_attach_api_body = {
+                'Name': vlan_name,
+                'VlanId': vlan_id,
+                'AutoAllowOnUplinks': auto_allow_on_uplinks,
+                'IsNative': is_native,
+                'EthNetworkPolicy': vlan_policy_moid
+            }
+
+            # Handle sharing configuration
+            if enable_sharing:
+                sharing_type = vlan_config.get('sharing_type')
+                vlan_attach_api_body['SharingType'] = sharing_type
+
+                # If Isolated or Community, primary_vlan_id is required
+                if sharing_type in ['Isolated', 'Community']:
+                    if 'primary_vlan_id' not in vlan_config:
+                        module.fail_json(msg=f"primary_vlan_id is required when sharing_type is {sharing_type}")
+                    vlan_attach_api_body['PrimaryVlanId'] = vlan_config['primary_vlan_id']
+                else:
+                    vlan_attach_api_body['PrimaryVlanId'] = 0
+            else:
+                # No sharing, use multicast policy
+                vlan_attach_api_body['SharingType'] = 'None'
+                vlan_attach_api_body['PrimaryVlanId'] = 0
+
+                # Get multicast policy name from vlan config
+                multicast_policy_name = vlan_config.get('multicast_policy_name')
+                if not multicast_policy_name:
+                    module.fail_json(msg="multicast_policy_name is required when enable_sharing is false")
+
+                # Check if multicast policy MOID is already cached
+                if multicast_policy_name in multicast_policy_cache:
+                    multicast_policy_moid = multicast_policy_cache[multicast_policy_name]
+                else:
+                    # Fetch multicast policy MOID and cache it
+                    multicast_policy_moid = intersight.get_moid_by_name(resource_path='/fabric/MulticastPolicies', resource_name=multicast_policy_name)
+                    multicast_policy_cache[multicast_policy_name] = multicast_policy_moid
+
+                vlan_attach_api_body['MulticastPolicy'] = multicast_policy_moid
+
+            # Create the VLAN
+            resource_path = '/fabric/Vlans'
+            intersight.api_body = vlan_attach_api_body
+            intersight.configure_secondary_resource(resource_path=resource_path, resource_name=vlan_name, state=vlan_config['state'])
+
+            # Store the VLAN response
+            final_response['vlans'].append(intersight.result['api_response'])
+
+            # Save the changed state and reset for next operation
+            save_changed_state_and_reset(intersight, changed_states)
+
+    # Set the final structured response
+    intersight.result['api_response'] = final_response
+
+    # Set final changed state based on whether any operation resulted in a change
+    intersight.result['changed'] = any(changed_states)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_vlan_policy_info.py
+++ b/plugins/modules/intersight_vlan_policy_info.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_vlan_policy_info
+short_description: Gather information about VLAN Policies and their VLANs in Cisco Intersight
+description:
+  - Retrieve comprehensive information about VLAN Policies and their associated VLANs from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization, policy name, or filter VLANs by name patterns.
+  - Returns structured data combining policy metadata with detailed VLAN configurations.
+  - Supports filtering by organization, policy name, and VLAN name.
+  - If no filters are provided, all VLAN Policies and their VLANs will be returned.
+  - Returns structured data with both policy information and associated VLAN details.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter VLAN Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the VLAN Policy to retrieve information from.
+      - When specified, only the matching policy and its VLANs will be returned.
+      - Can be combined with vlan_name filter to get specific VLANs from a specific policy.
+    type: str
+  vlan_name:
+    description:
+      - Filter VLANs by name within the policies.
+      - Can be used with or without policy name filtering.
+      - Supports exact matching (e.g., "prod_100" will match only "prod_100").
+      - When combined with policy name, filters VLANs within that specific policy.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all VLAN Policies and their VLANs from all organizations
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_vlan_policies
+
+# Organization-specific Examples
+- name: Fetch all VLAN Policies from the default organization
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all VLAN Policies from a custom organization
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific VLAN Policy by name with all its VLANs
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "datacenter-vlan-policy"
+  register: specific_policy
+
+- name: Display policy details
+  debug:
+    msg: "Policy {{ specific_policy.api_response.policy.Name }} has {{ specific_policy.api_response.vlans | length }} VLANs"
+
+# VLAN Filtering Examples
+- name: Find all policies containing a specific VLAN
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    vlan_name: "prod_100"
+  register: policies_with_prod_100
+
+- name: Find specific VLAN in a specific policy
+  cisco.intersight.intersight_vlan_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "datacenter-vlan-policy"
+    vlan_name: "mgmt_300"
+  register: specific_vlan_in_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing policy and VLAN information.
+    - Returns a dictionary when querying a single policy or no policies found.
+    - Returns a list when multiple policies are found.
+  returned: always
+  type: dict
+  contains:
+    vlan_policy:
+      description: VLAN policy information
+      type: dict
+      returned: always
+    vlans:
+      description: List of VLANs associated with the policy
+      type: list
+      returned: always
+  sample:
+    # Single policy response (when name parameter is used or only one policy found)
+    vlan_policy:
+      Name: "datacenter-vlan-policy"
+      ObjectType: "fabric.EthNetworkPolicy"
+      Moid: "12345678901234567890abcd"
+      Description: "VLAN policy for datacenter infrastructure"
+      Organization:
+        Name: "default"
+        ObjectType: "organization.Organization"
+      Tags:
+        - Key: "Site"
+          Value: "DataCenter-A"
+        - Key: "Environment"
+          Value: "Production"
+    vlans:
+      - Name: "prod_100"
+        ObjectType: "fabric.Vlan"
+        Moid: "vlan12345678901234567890"
+        VlanId: 100
+        AutoAllowOnUplinks: true
+        IsNative: false
+        SharingType: "None"
+        MulticastPolicy:
+          Name: "default-multicast-policy"
+          ObjectType: "fabric.MulticastPolicy"
+      - Name: "dmz_primary_50"
+        ObjectType: "fabric.Vlan"
+        Moid: "vlan09876543210987654321"
+        VlanId: 50
+        AutoAllowOnUplinks: true
+        IsNative: false
+        SharingType: "Primary"
+        PrimaryVlanId: 0
+      - Name: "dmz_isolated_51"
+        ObjectType: "fabric.Vlan"
+        Moid: "vlanabcdef1234567890123456"
+        VlanId: 51
+        AutoAllowOnUplinks: true
+        IsNative: false
+        SharingType: "Isolated"
+        PrimaryVlanId: 50
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def get_vlans_for_policy(intersight, policy_moid, vlan_name_filter=None):
+    """
+    Get all VLANs associated with a specific policy.
+
+    Args:
+        intersight: IntersightModule instance
+        policy_moid: MOID of the policy to get VLANs for
+        vlan_name_filter: Optional filter for VLAN names
+
+    Returns:
+        List of VLAN objects associated with the policy
+    """
+    # Build filter for VLANs associated with this policy
+    filter_conditions = [f"EthNetworkPolicy.Moid eq '{policy_moid}'"]
+
+    # Add VLAN name filter if provided (exact match only)
+    if vlan_name_filter:
+        filter_conditions.append(f"Name eq '{vlan_name_filter}'")
+
+    query_params = {
+        '$filter': ' and '.join(filter_conditions)
+    }
+
+    # Reset api_response before the API call to avoid previous responses
+    intersight.result['api_response'] = {}
+
+    # Get VLANs for this policy
+    intersight.get_resource(
+        resource_path='/fabric/Vlans',
+        query_params=query_params,
+        return_list=True
+    )
+
+    # Capture the response immediately before it gets overwritten
+    vlans_response = intersight.result.get('api_response', [])
+
+    # Ensure we return a list
+    if isinstance(vlans_response, list):
+        return vlans_response
+    elif isinstance(vlans_response, dict):
+        return [vlans_response]
+    else:
+        return []
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str'),
+        vlan_name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+
+    # Resource path used to fetch policy info
+    resource_path = '/fabric/EthNetworkPolicies'
+
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+
+    # Reset api_response before the API call to avoid previous responses
+    intersight.result['api_response'] = {}
+
+    # Get VLAN policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    policies = intersight.result.get('api_response', [])
+    vlan_name_filter = module.params.get('vlan_name')
+
+    # Build structured response
+    structured_results = []
+
+    # Ensure policies is always a list for iteration, even if a single dict is returned
+    if isinstance(policies, dict):
+        policies = [policies]
+    elif not isinstance(policies, list):
+        policies = []
+
+    for policy in policies:
+        policy_moid = policy.get('Moid')
+        if not policy_moid:
+            continue
+
+        # Get VLANs for this policy
+        vlans = get_vlans_for_policy(intersight, policy_moid, vlan_name_filter)
+
+        # Create structured response for this policy
+        policy_result = {
+            'vlan_policy': policy,
+            'vlans': vlans
+        }
+
+        structured_results.append(policy_result)
+
+    # Create final response structure
+    final_api_response = None
+
+    # Set final response based on number of policies found
+    if len(structured_results) == 1:
+        # Single policy - return as dict
+        final_api_response = structured_results[0]
+    elif len(structured_results) > 1:
+        # Multiple policies - return as list
+        final_api_response = structured_results
+    else:
+        # No policies found - return empty structure
+        final_api_response = {
+            'vlan_policy': {},
+            'vlans': []
+        }
+
+    # Use intersight.result and update api_response directly
+    intersight.result['api_response'] = final_api_response
+    final_result = intersight.result
+
+    module.exit_json(**final_result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_vlan_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_vlan_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_vlan_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_vlan_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_vlan_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_vlan_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_vlan_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_vlan_policy/tasks/tests.yml
@@ -1,0 +1,335 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      state: absent 
+
+  - name: Create vlan policy - check-mode
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      description: "Test VLAN policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify vlan policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response.vlan_policy == {}
+        - creation_res_check_mode.api_response.vlans == []
+
+  - name: Create vlan policy
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      description: "Test VLAN policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: creation_res
+
+  - name: Fetch info after creation
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+      name: test_vlan_policy
+    register: creation_info_res
+
+  - name: Verify vlan policy creation by info
+    ansible.builtin.assert:
+      that:
+        - creation_res.changed
+        - creation_info_res.api_response.vlan_policy.Name == 'test_vlan_policy'
+
+  - name: Verify vlan policy creation response aligns with info response
+    ansible.builtin.assert:
+      that:
+        - creation_res.api_response.vlan_policy.Name == creation_info_res.api_response.vlan_policy.Name
+
+  - name: Create vlan policy (idempotency check)
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      description: "Test VLAN policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: creation_res_ide
+
+  - name: Verify vlan policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not creation_res_ide.changed
+
+  - name: Update description of an existing vlan policy
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      description: "Updated VLAN policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: changed_res
+
+  - name: Fetch info after change
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+      name: test_vlan_policy
+    register: change_info_res
+
+  - name: Verify vlan policy change by info
+    ansible.builtin.assert:
+      that:
+        - changed_res.changed
+        - change_info_res.api_response.vlan_policy.Name == 'test_vlan_policy'
+        - change_info_res.api_response.vlan_policy.Description == 'Updated VLAN policy description'
+
+  - name: Create another vlan policy
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_2
+      description: "Test another VLAN policy description"
+    register: creation_res_b
+
+  - name: Fetch all vlan policies under selected organization
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+    register: creation_info_res_b
+
+  - name: Check that there are at least 2 vlan policies under this organization
+    ansible.builtin.assert:
+      that:
+        - creation_info_res_b.api_response | length > 1
+
+  - name: Test creation without optional parameters
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_minimal
+    register: creation_res_minimal
+
+  - name: Verify minimal vlan policy creation
+    ansible.builtin.assert:
+      that:
+        - creation_res_minimal.changed
+        - creation_res_minimal.api_response.vlan_policy.Name == 'test_vlan_policy_minimal'
+
+  - name: Create Multicast policy
+    cisco.intersight.intersight_multicast_policy:
+      <<: *api_info
+      name: multicast_policy_for_vlan_policy
+      description: "Test multicast policy description"
+    register: multicast_policy_res
+  
+  # Test VLAN Policy with VLANs
+  - name: Create VLAN policy with standard VLANs
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_with_vlans
+      description: "Policy with standard VLANs"
+      vlans:
+        - prefix: "prod"
+          vlan_id: 100
+          auto_allow_on_uplinks: true
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+          is_native: false
+          state: present
+        - prefix: "dev"
+          vlan_id: 200
+          auto_allow_on_uplinks: false
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+          is_native: false
+          state: present
+        - prefix: "mgmt"
+          vlan_id: 300
+          auto_allow_on_uplinks: true
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+          is_native: true
+    register: vlan_policy_with_vlans
+
+  - name: Verify VLAN policy with VLANs creation
+    ansible.builtin.assert:
+      that:
+        - vlan_policy_with_vlans.changed
+        - vlan_policy_with_vlans.api_response.vlan_policy.Name == 'test_vlan_policy_with_vlans'
+        - vlan_policy_with_vlans.api_response.vlans | length == 3
+        - vlan_policy_with_vlans.api_response.vlans[0].Name == 'prod_100'
+        - vlan_policy_with_vlans.api_response.vlans[1].Name == 'dev_200'
+        - vlan_policy_with_vlans.api_response.vlans[2].Name == 'mgmt_300'
+        - vlan_policy_with_vlans.api_response.vlans[0].IsNative == false
+        - vlan_policy_with_vlans.api_response.vlans[2].IsNative == true
+        - vlan_policy_with_vlans.api_response.vlans[0].VlanId == 100
+        - vlan_policy_with_vlans.api_response.vlans[1].VlanId == 200
+        - vlan_policy_with_vlans.api_response.vlans[2].VlanId == 300
+
+
+  - name: Create VLAN policy with Private VLANs
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_private_vlan_policy
+      description: "Policy with Private VLANs"
+      vlans:
+        - prefix: "primary"
+          vlan_id: 79
+          enable_sharing: true
+          sharing_type: "Primary"
+          auto_allow_on_uplinks: true
+        - prefix: "isolated"
+          vlan_id: 80
+          enable_sharing: true
+          sharing_type: "Isolated"
+          primary_vlan_id: 79
+          auto_allow_on_uplinks: true
+        - prefix: "community"
+          vlan_id: 81
+          enable_sharing: true
+          sharing_type: "Community"
+          primary_vlan_id: 79
+          auto_allow_on_uplinks: true
+    register: private_vlan_policy
+
+  - name: Verify Private VLAN policy creation
+    ansible.builtin.assert:
+      that:
+        - private_vlan_policy.changed
+        - private_vlan_policy.api_response.vlan_policy.Name == 'test_private_vlan_policy'
+        - private_vlan_policy.api_response.vlans | length == 3
+        - private_vlan_policy.api_response.vlans[0].Name == 'primary_79'
+        - private_vlan_policy.api_response.vlans[1].Name == 'isolated_80'
+        - private_vlan_policy.api_response.vlans[2].Name == 'community_81'
+        - private_vlan_policy.api_response.vlans[0].VlanId == 79
+        - private_vlan_policy.api_response.vlans[1].VlanId == 80
+        - private_vlan_policy.api_response.vlans[2].VlanId == 81
+        - private_vlan_policy.api_response.vlans[0].SharingType == 'Primary'
+        - private_vlan_policy.api_response.vlans[1].SharingType == 'Isolated'
+        - private_vlan_policy.api_response.vlans[2].SharingType == 'Community'
+        - private_vlan_policy.api_response.vlans[1].PrimaryVlanId == 79
+        - private_vlan_policy.api_response.vlans[2].PrimaryVlanId == 79
+
+  # Test info module with various filters
+  - name: Test info module - fetch specific policy with VLANs
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+      name: test_vlan_policy_with_vlans
+    register: specific_policy_info
+
+  - name: Verify specific policy info
+    ansible.builtin.assert:
+      that:
+        - specific_policy_info.api_response.vlan_policy.Name == 'test_vlan_policy_with_vlans'
+        - specific_policy_info.api_response.vlans | length == 4
+
+  - name: Test info module - fetch all policies
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+    register: all_policies_info
+
+  - name: Verify all policies info
+    ansible.builtin.assert:
+      that:
+        - all_policies_info.api_response | length >= 4
+
+  - name: Test info module - filter by VLAN name
+    cisco.intersight.intersight_vlan_policy_info:
+      <<: *api_info
+      vlan_name: "prod_100"
+      name: test_vlan_policy_with_vlans
+    register: vlan_filtered_info
+
+  - name: Verify VLAN filtered info
+    ansible.builtin.assert:
+      that:
+        - vlan_filtered_info.api_response.vlans | length == 1
+        - vlan_filtered_info.api_response.vlan_policy.Name == 'test_vlan_policy_with_vlans'
+        - vlan_filtered_info.api_response.vlans[0].Name == 'prod_100'
+        - vlan_filtered_info.api_response.vlans[0].VlanId == 100
+        - vlan_filtered_info.api_response.vlans[0].IsNative == false
+        - vlan_filtered_info.api_response.vlans[0].AutoAllowOnUplinks == true
+
+  # Test VLAN removal
+  - name: Update VLAN policy - remove one VLAN
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_with_vlans
+      description: "Policy with reduced VLANs"
+      vlans:
+        - prefix: "prod"
+          vlan_id: 100
+          auto_allow_on_uplinks: true
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+        - prefix: "dev"
+          vlan_id: 200
+          auto_allow_on_uplinks: false
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+          state: absent
+        - prefix: "mgmt"
+          vlan_id: 300
+          auto_allow_on_uplinks: true
+          enable_sharing: false
+          multicast_policy_name: "multicast_policy_for_vlan_policy"
+          is_native: true
+    register: vlan_removal_result
+
+  - name: Verify VLAN removal
+    ansible.builtin.assert:
+      that:
+        - vlan_removal_result.changed
+        - vlan_removal_result.api_response.vlan_policy.Name == 'test_vlan_policy_with_vlans'
+        - vlan_removal_result.api_response.vlans | length == 3
+
+  always:
+  - name: Remove vlan policy 1
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy
+      state: absent
+
+  - name: Remove vlan policy 2
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_2
+      state: absent
+
+  - name: Remove vlan policy minimal
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_minimal
+      state: absent
+
+  - name: Remove vlan policy with vlans
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_vlan_policy_with_vlans
+      state: absent
+
+  - name: Remove private vlan policy
+    cisco.intersight.intersight_vlan_policy:
+      <<: *api_info
+      name: test_private_vlan_policy
+      state: absent


### PR DESCRIPTION
#### SUMMARY
- Create vlan policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_vlan_policy.py
- plugins/modules/intersight_vlan_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests