### PR TITLE
Add integration tests for legacy modules

### DIFF
--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -142,6 +142,11 @@ def compare_values(expected, actual):
             # Compare the MOID string against the Moid field in the object reference
             if actual['Moid'] == expected:
                 return True
+        # Handle case where expected is a string and actual is an object reference
+        elif (isinstance(expected, str) and isinstance(actual, dict) and
+              'Name' in actual and actual.get('ObjectType') == 'organization.Organization'):
+            if actual['Name'] == expected:
+                return True
         # if expected and actual != expected:
         if actual != expected:
             return False

--- a/plugins/modules/intersight_bios_policy.py
+++ b/plugins/modules/intersight_bios_policy.py
@@ -8524,11 +8524,14 @@ def main():
     intersight.api_body = {
         'Name': intersight.module.params['name'],
         'Organization': {
-            'Name': intersight.module.params['organization'],
-        },
-        'Tags': intersight.module.params['tags'],
-        'Description': intersight.module.params['description'],
+            'Name': intersight.module.params['organization']
+        }
     }
+    if intersight.module.params['tags']:
+        intersight.api_body['Tags'] = intersight.module.params['tags']
+    if intersight.module.params['description']:
+        intersight.api_body['Description'] = intersight.module.params['description']
+
     check_and_add_prop('AcsControlGpu1state', 'acs_control_gpu1state', intersight.module.params, intersight.api_body)
     check_and_add_prop('AcsControlGpu2state', 'acs_control_gpu2state', intersight.module.params, intersight.api_body)
     check_and_add_prop('AcsControlGpu3state', 'acs_control_gpu3state', intersight.module.params, intersight.api_body)

--- a/plugins/modules/intersight_ntp_policy.py
+++ b/plugins/modules/intersight_ntp_policy.py
@@ -147,13 +147,22 @@ def main():
             'Name': intersight.module.params['organization'],
         },
         'Name': intersight.module.params['name'],
-        'Tags': intersight.module.params['tags'],
-        'Description': intersight.module.params['description'],
-        'Enabled': intersight.module.params['enable'],
-        'NtpServers': intersight.module.params['ntp_servers'],
-        'Timezone': intersight.module.params['timezone'],
+        'Enabled': intersight.module.params['enable']
     }
-
+    if intersight.module.params['state'] == 'present':
+        if not intersight.module.params['ntp_servers'] and intersight.module.params['enable']:
+            intersight.module.fail_json(msg="NTP servers are required when state is present and NTP is enabled")
+        else:
+            intersight.api_body['NtpServers'] = intersight.module.params['ntp_servers']
+        if intersight.module.params['timezone']:
+            intersight.api_body['Timezone'] = intersight.module.params['timezone']
+        if intersight.module.params['tags']:
+            intersight.api_body['Tags'] = intersight.module.params['tags']
+        if intersight.module.params['description']:
+            intersight.api_body['Description'] = intersight.module.params['description']
+        # Prevent a case where idempotency fails because of NtpServers (None vs [])
+        if intersight.module.params['enable'] is False:
+            intersight.api_body['NtpServers'] = []
     #
     # Code below should be common across all policy modules
     #

--- a/tests/integration/targets/intersight_bios_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_bios_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_bios_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_bios_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_bios_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_bios_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_bios_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_bios_policy/tasks/tests.yml
@@ -1,0 +1,152 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_bios_policy_basic
+      - test_bios_policy_updated
+      - test_bios_policy_with_settings
+
+  # Test 1: Basic BIOS Policy Creation
+  - name: Create basic BIOS policy - check-mode
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_basic
+      description: "Test basic BIOS policy"
+      tags:
+        - Key: Site
+          Value: Test
+    check_mode: true
+    register: basic_creation_check_mode
+
+  - name: Verify basic BIOS policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - basic_creation_check_mode is changed
+        - basic_creation_check_mode.api_response == {}
+
+  - name: Create basic BIOS policy
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_basic
+      description: "Test basic BIOS policy"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation
+
+  - name: Verify basic BIOS policy creation
+    ansible.builtin.assert:
+      that:
+        - basic_creation.changed
+
+  - name: Create basic BIOS policy (idempotency check)
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_basic
+      description: "Test basic BIOS policy"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation_ide
+
+  - name: Verify basic BIOS policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not basic_creation_ide.changed
+
+  # Test 2: BIOS Policy with specific settings
+  - name: Create BIOS policy with specific settings
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_with_settings
+      description: "Test BIOS policy with specific settings"
+      intel_hyper_threading_tech: "enabled"
+      intel_turbo_boost_tech: "enabled" 
+      intel_virtualization_technology: "enabled"
+      tags:
+        - Key: Environment
+          Value: Test
+    register: settings_creation
+
+  - name: Verify BIOS policy with settings creation
+    ansible.builtin.assert:
+      that:
+        - settings_creation.changed
+
+  - name: Create BIOS policy with settings (idempotency check)
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_with_settings
+      description: "Test BIOS policy with specific settings"
+      intel_hyper_threading_tech: "enabled"
+      intel_turbo_boost_tech: "enabled"
+      intel_virtualization_technology: "enabled"
+      tags:
+        - Key: Environment
+          Value: Test
+    register: settings_creation_ide
+
+  - name: Verify BIOS policy with settings (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not settings_creation_ide.changed
+
+  # Test 3: Update BIOS Policy
+  - name: Update BIOS policy description
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_basic
+      description: "Updated test basic BIOS policy"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Updated
+          Value: "true"
+    register: basic_update
+
+  - name: Verify BIOS policy update
+    ansible.builtin.assert:
+      that:
+        - basic_update.changed
+
+  - name: Update BIOS policy settings
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: test_bios_policy_with_settings
+      description: "Updated BIOS policy with modified settings"
+      intel_hyper_threading_tech: "disabled"
+      intel_turbo_boost_tech: "enabled"
+      intel_virtualization_technology: "disabled"
+      tags:
+        - Key: Environment
+          Value: Updated
+    register: settings_update
+
+  - name: Verify BIOS policy settings update
+    ansible.builtin.assert:
+      that:
+        - settings_update.changed
+
+  always:
+  - name: Remove all test BIOS policies
+    cisco.intersight.intersight_bios_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_bios_policy_basic
+      - test_bios_policy_updated
+      - test_bios_policy_with_settings

--- a/tests/integration/targets/intersight_ntp_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_ntp_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_ntp_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_ntp_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_ntp_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_ntp_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
@@ -1,0 +1,231 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_ntp_policy_basic
+      - test_ntp_policy_disabled
+      - test_ntp_policy_with_servers
+      - test_ntp_policy_updated
+
+  # Test 1: Basic NTP Policy Creation
+  - name: Create basic NTP policy - check-mode
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_basic
+      ntp_servers:
+        - pool.ntp.org
+      description: "Test basic NTP policy"
+      enable: true
+      tags:
+        - Key: Site
+          Value: Test
+    check_mode: true
+    register: basic_creation_check_mode
+
+  - name: Verify basic NTP policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - basic_creation_check_mode is changed
+        - basic_creation_check_mode.api_response == {}
+
+  - name: Create basic NTP policy
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_basic
+      ntp_servers:
+        - pool.ntp.org
+        - time.google.com
+      description: "Test basic NTP policy"
+      enable: true
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation
+
+  - name: Verify basic NTP policy creation
+    ansible.builtin.assert:
+      that:
+        - basic_creation.changed
+
+  - name: Create basic NTP policy (idempotency check)
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_basic
+      ntp_servers:
+        - pool.ntp.org
+        - time.google.com
+      description: "Test basic NTP policy"
+      enable: true
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation_ide
+
+  - name: Verify basic NTP policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not basic_creation_ide.changed
+
+  # Test 2: Disabled NTP Policy
+  - name: Create disabled NTP policy
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_disabled
+      description: "Test disabled NTP policy"
+      enable: false
+      tags:
+        - Key: Environment
+          Value: Test
+    register: disabled_creation
+
+  - name: Verify disabled NTP policy creation
+    ansible.builtin.assert:
+      that:
+        - disabled_creation.changed
+
+  - name: Create disabled NTP policy (idempotency check)
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_disabled
+      description: "Test disabled NTP policy"
+      enable: false
+      tags:
+        - Key: Environment
+          Value: Test
+    register: disabled_creation_ide
+
+  - name: Verify disabled NTP policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not disabled_creation_ide.changed
+
+  # Test 3: NTP Policy with servers and timezone
+  - name: Create NTP policy with servers and timezone
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_with_servers
+      description: "Test NTP policy with servers and timezone"
+      enable: true
+      ntp_servers:
+        - pool.ntp.org
+        - time.google.com
+        - time.cloudflare.com
+      timezone: "America/New_York"
+      tags:
+        - Key: Configuration
+          Value: Complete
+    register: servers_creation
+
+  - name: Verify NTP policy with servers creation
+    ansible.builtin.assert:
+      that:
+        - servers_creation.changed
+
+  - name: Create NTP policy with servers (idempotency check)
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_with_servers
+      description: "Test NTP policy with servers and timezone"
+      enable: true
+      ntp_servers:
+        - pool.ntp.org
+        - time.google.com
+        - time.cloudflare.com
+      timezone: "America/New_York"
+      tags:
+        - Key: Configuration
+          Value: Complete
+    register: servers_creation_ide
+
+  - name: Verify NTP policy with servers (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not servers_creation_ide.changed
+
+  # Test 4: Update NTP Policy
+  - name: Update basic NTP policy description
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_basic
+      description: "Updated test basic NTP policy"
+      enable: true
+      ntp_servers:
+        - pool.ntp.org
+        - time.google.com
+        - time.cloudflare.com
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Updated
+          Value: "true"
+    register: basic_update
+
+  - name: Verify basic NTP policy update
+    ansible.builtin.assert:
+      that:
+        - basic_update.changed
+
+  - name: Update NTP policy servers and timezone
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_with_servers
+      description: "Updated NTP policy with modified servers"
+      enable: true
+      ntp_servers:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
+        - ntp.ubuntu.com
+      timezone: "America/Chicago"
+      tags:
+        - Key: Configuration
+          Value: Updated
+    register: servers_update
+
+  - name: Verify NTP policy servers update
+    ansible.builtin.assert:
+      that:
+        - servers_update.changed
+
+  - name: Disable NTP policy
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: test_ntp_policy_disabled
+      description: "Updated disabled NTP policy"
+      enable: false
+      ntp_servers:
+        - disabled.ntp.server
+      timezone: "UTC"
+      tags:
+        - Key: Environment
+          Value: Disabled
+    register: disabled_update
+
+  - name: Verify disabled NTP policy update
+    ansible.builtin.assert:
+      that:
+        - disabled_update.changed
+
+  always:
+  - name: Remove all test NTP policies
+    cisco.intersight.intersight_ntp_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_ntp_policy_basic
+      - test_ntp_policy_disabled
+      - test_ntp_policy_with_servers
+      - test_ntp_policy_updated 

--- a/tests/integration/targets/intersight_rest_api/defaults/main.yml
+++ b/tests/integration/targets/intersight_rest_api/defaults/main.yml
@@ -1,0 +1,7 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"
+
+# Test resource names
+test_thermal_policy_name: "test_rest_api_thermal_policy"
+test_multicast_policy_name: "test_rest_api_multicast_policy" 

--- a/tests/integration/targets/intersight_rest_api/meta/main.yml
+++ b/tests/integration/targets/intersight_rest_api/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_rest_api/tasks/main.yml
+++ b/tests/integration/targets/intersight_rest_api/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Run tests
+  include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_rest_api/tasks/tests.yml
+++ b/tests/integration/targets/intersight_rest_api/tasks/tests.yml
@@ -1,0 +1,346 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+
+  
+  # Fetch Organization MOID
+  - name: Get organization details using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: /organization/Organizations
+      query_params:
+        $filter: "Name eq '{{ organization }}'"
+    register: org_result
+
+  - name: Set organization MOID fact
+    ansible.builtin.set_fact:
+      organization_moid: "{{ org_result.api_response.Moid }}"
+
+  - name: Verify organization was found
+    ansible.builtin.assert:
+      that:
+        - org_result.api_response.Name == organization
+        - organization_moid is defined
+        - organization_moid | length > 0
+
+  # Cleanup
+  - name: Clean up test thermal policy using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      query_params:
+        $filter: "Name eq '{{ test_thermal_policy_name }}'"
+      state: absent
+
+  - name: Clean up test multicast policy using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/fabric/MulticastPolicies"
+      query_params:
+        $filter: "Name eq '{{ test_multicast_policy_name }}'"
+      state: absent
+
+  # Thermal Policy Tests
+  - name: Create thermal policy using REST API - check mode
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_thermal_policy_name }}",
+          "FanControlMode": "Balanced",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            },
+            {
+              "Key": "Environment", 
+              "Value": "CI"
+            }
+          ]
+        }
+    check_mode: true
+    register: thermal_create_check
+
+  - name: Verify thermal policy was not created in check mode
+    ansible.builtin.assert:
+      that:
+        - thermal_create_check is changed
+        - thermal_create_check.api_response == {}
+
+  - name: Create thermal policy using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_thermal_policy_name }}",
+          "FanControlMode": "Balanced",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            },
+            {
+              "Key": "Environment", 
+              "Value": "CI"
+            }
+          ]
+        }
+    register: thermal_create
+
+  - name: Verify thermal policy was created via REST API
+    ansible.builtin.assert:
+      that:
+        - thermal_create is changed
+        - thermal_create.api_response.Name == test_thermal_policy_name
+        - thermal_create.api_response.FanControlMode == "Balanced"
+
+  - name: Verify thermal policy creation using dedicated info module
+    cisco.intersight.intersight_thermal_policy_info:
+      <<: *api_info
+      name: "{{ test_thermal_policy_name }}"
+    register: thermal_info_verify
+
+  - name: Assert thermal policy was created correctly using info module
+    ansible.builtin.assert:
+      that:
+        - thermal_info_verify.api_response | length == 1
+        - thermal_info_verify.api_response[0].Name == test_thermal_policy_name
+        - thermal_info_verify.api_response[0].FanControlMode == "Balanced"
+
+  - name: Get thermal policy using REST API with query filter
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      query_params:
+        $filter: "Name eq '{{ test_thermal_policy_name }}'"
+    register: thermal_get
+
+  - name: Verify thermal policy GET operation
+    ansible.builtin.assert:
+      that:
+        - thermal_get is not changed
+        - thermal_get.api_response.Name == test_thermal_policy_name
+        - thermal_get.api_response.FanControlMode == "Balanced"
+
+  - name: Create thermal policy using REST API - idempotency check
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      query_params:
+        $filter: "Name eq '{{ test_thermal_policy_name }}'"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_thermal_policy_name }}",
+          "FanControlMode": "Balanced",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            },
+            {
+              "Key": "Environment", 
+              "Value": "CI"
+            }
+          ]
+        }
+    register: thermal_create_idem
+
+  - name: Verify thermal policy creation is idempotent
+    ansible.builtin.assert:
+      that:
+        - thermal_create_idem is not changed
+
+  - name: Update thermal policy using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/thermal/Policies"
+      query_params:
+        $filter: "Name eq '{{ test_thermal_policy_name }}'"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_thermal_policy_name }}",
+          "FanControlMode": "HighPower",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            },
+            {
+              "Key": "Environment", 
+              "Value": "CI"
+            }
+          ]
+        }
+    register: thermal_update
+
+  - name: Verify thermal policy was updated via REST API
+    ansible.builtin.assert:
+      that:
+        - thermal_update is changed
+        - thermal_update.api_response.FanControlMode == "HighPower"
+
+  - name: Verify thermal policy update using dedicated info module
+    cisco.intersight.intersight_thermal_policy_info:
+      <<: *api_info
+      name: "{{ test_thermal_policy_name }}"
+    register: thermal_info_update
+
+  - name: Assert thermal policy was updated correctly
+    ansible.builtin.assert:
+      that:
+        - thermal_info_update.api_response[0].FanControlMode == "HighPower"
+
+  # Multicast Policy Tests
+  - name: Create multicast policy using REST API
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/fabric/MulticastPolicies"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_multicast_policy_name }}",
+          "QuerierState": "Disabled",
+          "SnoopingState": "Enabled",
+          "SrcIpProxy": "Enabled",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            }
+          ]
+        }
+    register: multicast_create
+
+  - name: Verify multicast policy was created via REST API
+    ansible.builtin.assert:
+      that:
+        - multicast_create is changed
+        - multicast_create.api_response.Name == test_multicast_policy_name
+        - multicast_create.api_response.QuerierState == "Disabled"
+        - multicast_create.api_response.SnoopingState == "Enabled"
+
+  - name: Verify multicast policy creation using dedicated info module
+    cisco.intersight.intersight_multicast_policy_info:
+      <<: *api_info
+      name: "{{ test_multicast_policy_name }}"
+    register: multicast_info_verify
+
+  - name: Assert multicast policy was created correctly using info module
+    ansible.builtin.assert:
+      that:
+        - multicast_info_verify.api_response | length == 1
+        - multicast_info_verify.api_response[0].Name == test_multicast_policy_name
+        - multicast_info_verify.api_response[0].QuerierState == "Disabled"
+        - multicast_info_verify.api_response[0].SnoopingState == "Enabled"
+
+  - name: Update multicast policy using REST API (enable querier)
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/fabric/MulticastPolicies"
+      query_params:
+        $filter: "Name eq '{{ test_multicast_policy_name }}'"
+      update_method: post
+      api_body: |
+        {
+          "Organization": {
+            "ObjectType": "organization.Organization",
+            "Moid": "{{ organization_moid }}"
+          },
+          "Name": "{{ test_multicast_policy_name }}",
+          "QuerierState": "Enabled",
+          "QuerierIpAddress": "192.168.1.10",
+          "QuerierIpAddressPeer": "192.168.1.11",
+          "SnoopingState": "Enabled",
+          "SrcIpProxy": "Enabled",
+          "Tags": [
+            {
+              "Key": "Test",
+              "Value": "RestAPI"
+            }
+          ]
+        }
+    register: multicast_update
+
+  - name: Verify multicast policy was updated via REST API
+    ansible.builtin.assert:
+      that:
+        - multicast_update is changed
+        - multicast_update.api_response.QuerierState == "Enabled"
+        - multicast_update.api_response.QuerierIpAddress == "192.168.1.10"
+
+  - name: Verify multicast policy update using dedicated info module
+    cisco.intersight.intersight_multicast_policy_info:
+      <<: *api_info
+      name: "{{ test_multicast_policy_name }}"
+    register: multicast_info_update
+
+  - name: Assert multicast policy was updated correctly
+    ansible.builtin.assert:
+      that:
+        - multicast_info_update.api_response[0].QuerierState == "Enabled"
+        - multicast_info_update.api_response[0].QuerierIpAddress == "192.168.1.10"
+
+  # Error Handling Test
+  - name: Test invalid resource path (should fail gracefully)
+    cisco.intersight.intersight_rest_api:
+      <<: *api_info
+      resource_path: "/invalid/ResourcePath"
+      query_params:
+        $filter: "Name eq 'non-existent'"
+    register: invalid_path_result
+    failed_when:
+      - invalid_path_result is failed
+      - not "'Operation not supported. Check if the API path and method are valid' in invalid_path_result.msg"
+
+  always:
+    # Cleanup
+    - name: Delete thermal policy using REST API
+      cisco.intersight.intersight_rest_api:
+        <<: *api_info
+        resource_path: "/thermal/Policies"
+        query_params:
+          $filter: "Name eq '{{ test_thermal_policy_name }}'"
+        state: absent
+      failed_when: false
+
+    - name: Delete multicast policy using REST API
+      cisco.intersight.intersight_rest_api:
+        <<: *api_info
+        resource_path: "/fabric/MulticastPolicies"
+        query_params:
+          $filter: "Name eq '{{ test_multicast_policy_name }}'"
+        state: absent
+      failed_when: false


### PR DESCRIPTION
Adding integration tests for:
ntersight_bios_policy, intersight_ntp_policy, and intersight_rest_api .