### PR TITLE
Run integration tests only on targeted modules

### DIFF
--- a/.github/scripts/map_changes_to_tests.py
+++ b/.github/scripts/map_changes_to_tests.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Script to map changed files in a PR to corresponding integration test targets.
+This helps run only relevant tests instead of the full test suite.
+"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def get_changed_files():
+    """Get list of changed files in the current PR/commit."""
+    try:
+        # For PR context, compare against the base branch
+        if os.getenv('GITHUB_EVENT_NAME') == 'pull_request':
+            base_ref = os.getenv('GITHUB_BASE_REF', 'main')
+            result = subprocess.run(
+                ['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+        else:
+            # For push events, compare against previous commit
+            result = subprocess.run(
+                ['git', 'diff', '--name-only', 'HEAD~1'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+        
+        changed_files = result.stdout.strip().split('\n')
+        return [f for f in changed_files if f.strip()]
+    
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting changed files: {e}")
+        return []
+
+
+def map_files_to_test_targets(changed_files):
+    """Map changed files to their corresponding integration test targets."""
+    test_targets = set()
+    
+    # Get available test targets
+    test_targets_dir = Path('tests/integration/targets')
+    available_targets = {
+        target.name for target in test_targets_dir.iterdir() 
+        if target.is_dir() and not target.name.startswith('__')
+    }
+    
+    for file_path in changed_files:
+        path = Path(file_path)
+        
+        # Skip non-relevant files
+        if any(skip_pattern in str(path) for skip_pattern in [
+            '.github/', 'README', '.gitignore', 'LICENSE', 
+            'CHANGELOG', 'requirements.txt', 'galaxy.yml'
+        ]):
+            continue
+            
+        # Handle module files
+        if path.parts[0] == 'plugins' and len(path.parts) > 2 and path.parts[1] == 'modules':
+            module_name = path.stem
+            
+            # Remove '_info' suffix if present (info modules use same test target)
+            if module_name.endswith('_info'):
+                module_name = module_name[:-5]
+            
+            if module_name in available_targets:
+                test_targets.add(module_name)
+                print(f"✓ Mapped {file_path} -> {module_name}")
+            else:
+                print(f"⚠ No test target found for module: {module_name}")
+                print(f"  Available targets: {sorted(available_targets)}")
+        
+        # Handle module_utils changes - these affect multiple modules
+        elif path.parts[0] == 'plugins' and 'module_utils' in path.parts:
+            print(f"Module utils changed: {file_path}")
+            # For module_utils changes, we could run core tests or all tests
+            # Let's run a representative set of core tests
+            core_tests = {'intersight_rest_api', 'intersight_info'} & available_targets
+            test_targets.update(core_tests)
+            print(f"Added core tests for module_utils change: {core_tests}")
+        
+        # Handle test files themselves
+        elif path.parts[0] == 'tests' and 'integration' in path.parts:
+            for part in path.parts:
+                if part in available_targets:
+                    test_targets.add(part)
+                    print(f"Mapped test file {file_path} -> {part}")
+                    break
+        
+        # Handle playbook changes
+        elif path.parts[0] == 'playbooks':
+            # Playbook changes might affect multiple modules
+            # For now, let's run a basic set of tests
+            basic_tests = {'intersight_info'} & available_targets
+            test_targets.update(basic_tests)
+            print(f"Added basic tests for playbook change: {file_path}")
+    
+    return sorted(list(test_targets))
+
+
+def main():
+    # For workflow_dispatch events, allow running all tests if no specific files changed
+    event_name = os.getenv('GITHUB_EVENT_NAME')
+    if event_name == 'workflow_dispatch':
+        print("Manual workflow dispatch detected")
+        # Check for special environment variable to force all tests
+        if os.getenv('RUN_ALL_TESTS', '').lower() == 'true':
+            test_targets_dir = Path('tests/integration/targets')
+            available_targets = [
+                target.name for target in test_targets_dir.iterdir() 
+                if target.is_dir() and not target.name.startswith('__')
+            ]
+            targets_string = ' '.join(available_targets)
+            print(f"Running all available test targets: {available_targets}")
+            github_output = os.getenv('GITHUB_OUTPUT')
+            if github_output:
+                with open(github_output, 'a') as f:
+                    f.write(f"targets={targets_string}\n")
+                    f.write("skip_tests=false\n")
+            return
+    
+    # Get changed files
+    changed_files = get_changed_files()
+    
+    if not changed_files:
+        print("No changed files detected")
+        # Use modern GitHub Actions output format
+        github_output = os.getenv('GITHUB_OUTPUT')
+        if github_output:
+            with open(github_output, 'a') as f:
+                f.write("targets=\n")
+                f.write("skip_tests=true\n")
+        return
+    
+    print(f"Changed files: {changed_files}")
+    
+    # Map to test targets
+    test_targets = map_files_to_test_targets(changed_files)
+    
+    github_output = os.getenv('GITHUB_OUTPUT')
+    if not test_targets:
+        print("No integration tests needed for the changed files")
+        if github_output:
+            with open(github_output, 'a') as f:
+                f.write("targets=\n")
+                f.write("skip_tests=true\n")
+    else:
+        targets_string = ' '.join(test_targets)
+        print(f"Test targets to run: {test_targets}")
+        if github_output:
+            with open(github_output, 'a') as f:
+                f.write(f"targets={targets_string}\n")
+                f.write("skip_tests=false\n")
+
+
+if __name__ == '__main__':
+    main() 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,6 +2,15 @@
 name: Ansible-test CI
 on:
   workflow_dispatch:
+    inputs:
+      run_all_tests:
+        description: 'Run all integration tests (true/false)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
   push:
     branches:
       - stable-ci
@@ -18,8 +27,40 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  detect-changes:
+    name: Detect Changed Files
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.map-tests.outputs.targets }}
+      skip_tests: ${{ steps.map-tests.outputs.skip_tests }}
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        if: steps.checkAccess.outputs.require-result == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0  # Fetch full history for comparison
+
+      - name: Map changed files to test targets
+        if: steps.checkAccess.outputs.require-result == 'true'
+        id: map-tests
+        env:
+          RUN_ALL_TESTS: ${{ github.event.inputs.run_all_tests }}
+        run: |
+          python3 .github/scripts/map_changes_to_tests.py
+
   integration:
     name: >-
       Integration (Ⓐ${{ matrix.ansible }})
@@ -27,6 +68,8 @@ jobs:
       ${{ contains(fromJson(
           '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.skip_tests != 'true'
     strategy:
       matrix:
         ansible:
@@ -43,6 +86,7 @@ jobs:
           username: ${{ github.triggering_actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
       # Run integration tests inside a Docker container.
       # The docker container has all the pinned dependencies that are
       # required and all Python versions Ansible supports.
@@ -54,11 +98,23 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: integration
+          target: ${{ needs.detect-changes.outputs.targets }}
           pre-test-cmd: chmod +x ./tests/integration/targets/prepare_test_run/generate_integration_config.sh && ./tests/integration/targets/prepare_test_run/generate_integration_config.sh
           git-checkout-ref: ${{ github.event.pull_request.head.sha }}
         env:
           API_PRIVATE_KEY: ${{ secrets.INTERSIGHT_API_PRIVATE_KEY_CI }}
           API_KEY_ID: ${{ secrets.INTERSIGHT_API_KEY_ID_CI }}
+
+  integration-skipped:
+    name: Integration (Skipped - No relevant changes)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.skip_tests == 'true'
+    steps:
+      - name: Log skip reason
+        run: |
+          echo "Integration tests skipped - no relevant changes detected"
+          echo "This job automatically succeeds to satisfy branch protection rules"
 
   check: # This job does nothing and is only used for the branch protection
     # or multi-stage CI jobs, like making sure that all tests pass before
@@ -66,7 +122,9 @@ jobs:
     if: always()
 
     needs:
+      - detect-changes
       - integration
+      - integration-skipped
 
     runs-on: ubuntu-latest
 
@@ -74,4 +132,6 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          # Allow skipping integration jobs when no changes detected
+          allowed-skips: integration, integration-skipped
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Prevent Integration tests from running all the integrations per PR made. This is in order to sustain scalability.