### PR TITLE
Link Control Policy Module

### DIFF
--- a/plugins/modules/intersight_link_control_policy.py
+++ b/plugins/modules/intersight_link_control_policy.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_link_control_policy
+short_description: Link Control Policy configuration for Cisco Intersight
+description:
+  - Manages Link Control Policy configuration on Cisco Intersight.
+  - A policy to configure UDLD (UniDirectional Link Detection) settings on Cisco Intersight managed devices.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/fabric/LinkControlPolicy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles, Policies, and Pools that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Link Control Policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Link Control Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  udld_admin_state:
+    description:
+      - UDLD Admin configured Link State for this port.
+    type: str
+    choices: ['Enabled', 'Disabled']
+    default: 'Enabled'
+  udld_mode:
+    description:
+      - UDLD Admin configured Mode for this port.
+      - Cannot be set to 'aggressive' when udld_admin_state is 'Disabled'.
+    type: str
+    choices: ['normal', 'aggressive']
+    default: 'normal'
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Configure Link Control Policy with UDLD enabled in aggressive mode
+  cisco.intersight.intersight_link_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "test-link-aggressive"
+    description: "Link Control Policy with aggressive UDLD"
+    udld_admin_state: "Enabled"
+    udld_mode: "aggressive"
+    tags:
+      - Key: Site
+        Value: DataCenter-A
+
+- name: Configure Link Control Policy with UDLD disabled
+  cisco.intersight.intersight_link_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "test-link-disabled"
+    description: "Link Control Policy with UDLD disabled"
+    udld_admin_state: "Disabled"
+    udld_mode: "normal"
+
+- name: Delete Link Control Policy
+  cisco.intersight.intersight_link_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "test-link-policy"
+    state: absent
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "test-link-policy",
+        "ObjectType": "fabric.LinkControlPolicy",
+        "UdldSettings": {
+            "AdminState": "Enabled",
+            "Mode": "aggressive",
+            "ClassId": "fabric.UdldSettings",
+            "ObjectType": "fabric.UdldSettings"
+        },
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "DataCenter-A"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def validate_udld_configuration(module):
+    """
+    Validate UDLD configuration to ensure aggressive mode is not used when admin state is disabled.
+    """
+    udld_admin_state = module.params['udld_admin_state']
+    udld_mode = module.params['udld_mode']
+
+    if udld_admin_state == 'Disabled' and udld_mode == 'aggressive':
+        module.fail_json(
+            msg="Cannot configure the link control policy. Mode should not be 'aggressive' when the policy is disabled."
+        )
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        udld_admin_state=dict(type='str', choices=['Enabled', 'Disabled'], default='Enabled'),
+        udld_mode=dict(type='str', choices=['normal', 'aggressive'], default='normal')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    # Validate UDLD configuration
+    validate_udld_configuration(module)
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    #
+    # Argument spec above, resource path, and API body should be the only code changed in each policy module
+    #
+    # Resource path used to configure policy
+    resource_path = '/fabric/LinkControlPolicies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+
+    if intersight.module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+        intersight.api_body['UdldSettings'] = {
+            'AdminState': intersight.module.params['udld_admin_state'],
+            'Mode': intersight.module.params['udld_mode']
+        }
+
+    #
+    # Code below should be common across all policy modules
+    #
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_link_control_policy_info.py
+++ b/plugins/modules/intersight_link_control_policy_info.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_link_control_policy_info
+short_description: Gather information about Link Control Policies in Cisco Intersight
+description:
+  - Gather information about Link Control Policies in L(Cisco Intersight,https://intersight.com).
+  - Information can be filtered by O(organization) and O(name).
+  - If no filters are passed, all Link Control Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization the Link Control Policy belongs to.
+    type: str
+  name:
+    description:
+      - The name of the Link Control Policy to gather information from.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Fetch a specific Link Control Policy by name
+  cisco.intersight.intersight_link_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "test-link-policy"
+
+- name: Fetch all Link Control Policies in a specific Organization
+  cisco.intersight.intersight_link_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+
+- name: Fetch all Link Control Policies
+  cisco.intersight.intersight_link_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": [
+    {
+        "Name": "test-link-policy",
+        "ObjectType": "fabric.LinkControlPolicy",
+        "UdldSettings": {
+            "AdminState": "Enabled",
+            "Mode": "aggressive",
+            "ClassId": "fabric.UdldSettings",
+            "ObjectType": "fabric.UdldSettings"
+        },
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "DataCenter-A"
+            }
+        ]
+    },
+    {
+        "Name": "test-link-disabled",
+        "ObjectType": "fabric.LinkControlPolicy",
+        "UdldSettings": {
+            "AdminState": "Disabled",
+            "Mode": "normal",
+            "ClassId": "fabric.UdldSettings",
+            "ObjectType": "fabric.UdldSettings"
+        },
+        "Tags": []
+    }
+  ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Resource path used to fetch info
+    resource_path = '/fabric/LinkControlPolicies'
+
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_link_control_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_link_control_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_link_control_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_link_control_policy/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_test_run 

--- a/tests/integration/targets/intersight_link_control_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_link_control_policy/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- import_tasks: tests.yml 

--- a/tests/integration/targets/intersight_link_control_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_link_control_policy/tasks/tests.yml
@@ -1,0 +1,192 @@
+---
+- name: Test intersight_link_control_policy module
+  block:
+    - name: Define anchor for Intersight API login info
+      ansible.builtin.set_fact:
+        api_info: &api_info
+          api_private_key: "{{ api_private_key }}"
+          api_key_id: "{{ api_key_id }}"
+          api_uri: "{{ api_uri | default(omit) }}"
+          validate_certs: "{{ validate_certs | default(omit) }}"
+          organization: "{{ organization }}"
+
+    - name: Make sure Env is clean
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - test_link_control_policy
+        - test_link_control_policy_2
+        - test_link_control_aggressive
+        - test_link_control_disabled
+
+    - name: Create link control policy - check-mode
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_policy
+        description: "Test link control policy description"
+        tags:
+          - Key: Site
+            Value: Test
+          - Key: Site2
+            Value: Test2
+        udld_admin_state: "Enabled"
+        udld_mode: "normal"
+      check_mode: true
+      register: creation_res_check_mode
+
+    - name: Verify link control policy was not created - check-mode
+      ansible.builtin.assert:
+        that:
+          - creation_res_check_mode is changed
+          - creation_res_check_mode.api_response == {}
+
+    - name: Create link control policy
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_policy
+        description: "Test link control policy description"
+        tags:
+          - Key: Site
+            Value: Test
+          - Key: Site2
+            Value: Test2
+        udld_admin_state: "Enabled"
+        udld_mode: "normal"
+      register: creation_res
+
+    - name: Fetch info after creation
+      cisco.intersight.intersight_link_control_policy_info:
+        <<: *api_info
+        name: test_link_control_policy
+      register: creation_info_res
+
+    - name: Verify link control policy creation by info
+      ansible.builtin.assert:
+        that:
+          - creation_res.changed
+          - creation_info_res.api_response[0].Name == 'test_link_control_policy'
+          - creation_info_res.api_response[0].UdldSettings.AdminState == 'Enabled'
+          - creation_info_res.api_response[0].UdldSettings.Mode == 'normal'
+
+    - name: Verify link control policy creation response aligns with info response
+      ansible.builtin.assert:
+        that:
+          - creation_res.api_response.Name == creation_info_res.api_response[0].Name
+          - creation_res.api_response.UdldSettings.AdminState == creation_info_res.api_response[0].UdldSettings.AdminState
+          - creation_res.api_response.UdldSettings.Mode == creation_info_res.api_response[0].UdldSettings.Mode
+
+    - name: Create link control policy (idempotency check)
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_policy
+        description: "Test link control policy description"
+        tags:
+          - Key: Site
+            Value: Test
+          - Key: Site2
+            Value: Test2
+        udld_admin_state: "Enabled"
+        udld_mode: "normal"
+      register: creation_res_ide
+
+    - name: Verify link control policy creation (idempotency check)
+      ansible.builtin.assert:
+        that:
+          - not creation_res_ide.changed
+
+    - name: Change UDLD mode to aggressive for existing link control policy
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_policy
+        udld_admin_state: "Enabled"
+        udld_mode: "aggressive"
+      register: changed_res
+
+    - name: Fetch info after change
+      cisco.intersight.intersight_link_control_policy_info:
+        <<: *api_info
+        name: test_link_control_policy
+      register: change_info_res
+
+    - name: Verify link control policy change by info
+      ansible.builtin.assert:
+        that:
+          - changed_res.changed
+          - change_info_res.api_response[0].Name == 'test_link_control_policy'
+          - change_info_res.api_response[0].UdldSettings.AdminState == 'Enabled'
+          - change_info_res.api_response[0].UdldSettings.Mode == 'aggressive'
+
+    - name: Create link control policy with aggressive mode enabled
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_aggressive
+        description: "Test link control policy with aggressive UDLD"
+        udld_admin_state: "Enabled"
+        udld_mode: "aggressive"
+      register: creation_res_aggressive
+
+    - name: Verify aggressive mode creation
+      ansible.builtin.assert:
+        that:
+          - creation_res_aggressive.changed
+          - creation_res_aggressive.api_response.UdldSettings.AdminState == 'Enabled'
+          - creation_res_aggressive.api_response.UdldSettings.Mode == 'aggressive'
+
+    - name: Create link control policy with UDLD disabled
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_disabled
+        description: "Test link control policy with UDLD disabled"
+        udld_admin_state: "Disabled"
+        udld_mode: "normal"
+      register: creation_res_disabled
+
+    - name: Verify disabled UDLD creation
+      ansible.builtin.assert:
+        that:
+          - creation_res_disabled.changed
+          - creation_res_disabled.api_response.UdldSettings.AdminState == 'Disabled'
+          - creation_res_disabled.api_response.UdldSettings.Mode == 'normal'
+
+    - name: Test failure case - try to create policy with disabled admin state and aggressive mode
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_invalid
+        udld_admin_state: "Disabled"
+        udld_mode: "aggressive"
+      register: validation_failure_res
+      failed_when:
+        - "not 'Cannot configure the link control policy.' in validation_failure_res.msg"
+
+    - name: Create another link control policy
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: test_link_control_policy_2
+        description: "Test another link control policy description"
+        udld_admin_state: "Enabled"
+        udld_mode: "normal"
+      register: creation_res_b
+
+    - name: Fetch all link control policies under selected organization
+      cisco.intersight.intersight_link_control_policy_info:
+        <<: *api_info
+      register: creation_info_res_b
+
+    - name: Check that there are at least 4 link control policies under this organization
+      ansible.builtin.assert:
+        that:
+          - creation_info_res_b.api_response | length >= 4
+
+  always:
+    - name: Remove link control policies
+      cisco.intersight.intersight_link_control_policy:
+        <<: *api_info
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - test_link_control_policy
+        - test_link_control_policy_2
+        - test_link_control_aggressive
+        - test_link_control_disabled


### PR DESCRIPTION
#### SUMMARY
- Create link control policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_link_control_policy.py
- plugins/modules/intersight_link_control_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests