### PR TITLE
Introduce ethernet network group policy

### DIFF
--- a/plugins/modules/intersight_ethernet_network_group_policy.py
+++ b/plugins/modules/intersight_ethernet_network_group_policy.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_ethernet_network_group_policy
+short_description: Ethernet Network Group Policy configuration for Cisco Intersight
+description:
+  - Manages Ethernet Network Group Policy configuration on Cisco Intersight.
+  - A policy to configure VLAN settings and QinQ (802.1Q-in-802.1Q) tunneling for Ethernet virtual interfaces on Cisco Intersight managed servers.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/fabric/EthNetworkGroupPolicy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+      - When C(absent), VLAN configuration parameters are not required.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles, Policies, and Pools that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Ethernet Network Group Policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Ethernet Network Group Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  qinq_enabled:
+    description:
+      - Enable QinQ (802.1Q-in-802.1Q) Tunneling on the vNIC.
+      - When enabled, C(qinq_vlan) is required and C(allowed_vlans) is ignored.
+      - When disabled, C(allowed_vlans) is required.
+    type: bool
+    default: false
+  qinq_vlan:
+    description:
+      - Set QinQ VLAN number.
+      - Required when C(qinq_enabled) is true.
+      - Only one QinQ VLAN can be specified.
+      - Valid range is 2-4093.
+    type: int
+  native_vlan:
+    description:
+      - Set native VLAN in case QinQ is enabled.
+      - Optional when C(qinq_enabled) is true.
+      - Only one native VLAN can be specified.
+      - Valid range is 1-4093.
+    type: int
+  allowed_vlans:
+    description:
+      - Include VLAN IDs using a list of comma separated VLAN IDs and VLAN ID Ranges.
+      - Required when C(qinq_enabled) is false.
+      - Examples of valid formats are C(1), C(1,2,3,4,8), C(1-4,7), C(1-8,12,16).
+      - Valid VLAN range is 1-4093.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create an Ethernet Network Group Policy with regular VLANs
+  cisco.intersight.intersight_ethernet_network_group_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "regular-vlans-policy"
+    description: "Policy with regular VLAN configuration"
+    qinq_enabled: false
+    allowed_vlans: "1-8,12,16"
+    state: present
+
+- name: Create an Ethernet Network Group Policy with QinQ enabled
+  cisco.intersight.intersight_ethernet_network_group_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "qinq-policy"
+    description: "Policy with QinQ configuration"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+    qinq_enabled: true
+    qinq_vlan: 4
+    native_vlan: 1
+    state: present
+
+- name: Create an Ethernet Network Group Policy with QinQ enabled (no native VLAN)
+  cisco.intersight.intersight_ethernet_network_group_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "qinq-no-native-policy"
+    description: "QinQ policy without native VLAN"
+    qinq_enabled: true
+    qinq_vlan: 100
+    state: present
+
+- name: Create an Ethernet Network Group Policy with single VLAN
+  cisco.intersight.intersight_ethernet_network_group_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "single-vlan-policy"
+    description: "Policy with single VLAN"
+    qinq_enabled: false
+    allowed_vlans: "50"
+    state: present
+
+- name: Delete an Ethernet Network Group Policy
+  cisco.intersight.intersight_ethernet_network_group_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "qinq-policy"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "regular-vlans-policy",
+        "ObjectType": "fabric.EthNetworkGroupPolicy",
+        "VlanSettings": {
+            "ClassId": "fabric.VlanSettings",
+            "ObjectType": "fabric.VlanSettings",
+            "QinqEnabled": false,
+            "AllowedVlans": "1-5,10,15-20"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Prod"
+            }
+        ]
+    }
+'''
+
+
+import re
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def validate_allowed_vlans_format(allowed_vlans):
+    """Validate allowed_vlans format and return parsed VLAN IDs"""
+    if not allowed_vlans or not allowed_vlans.strip():
+        return False, "allowed_vlans cannot be empty"
+
+    # Remove all whitespace
+    vlans_str = allowed_vlans.replace(' ', '')
+
+    # Pattern to match: single VLAN (123) or VLAN range (123-456)
+    # Full pattern: comma-separated list of single VLANs or ranges
+    pattern = r'^(\d+(-\d+)?)(,\d+(-\d+)?)*$'
+
+    if not re.match(pattern, vlans_str):
+        return False, "allowed_vlans must be in format '1', '1,2,3', '1-4', or '1-4,7,10-15'"
+
+    # Parse and validate individual VLAN IDs and ranges
+    vlan_parts = vlans_str.split(',')
+    for part in vlan_parts:
+        if '-' in part:
+            try:
+                start, end = part.split('-')
+                start_id, end_id = int(start), int(end)
+                if start_id >= end_id:
+                    return False, f"Invalid VLAN range '{part}': start must be less than end"
+                if start_id < 1 or start_id > 4093 or end_id < 1 or end_id > 4093:
+                    return False, f"VLAN IDs in range '{part}' must be between 1 and 4093"
+            except ValueError:
+                return False, f"Invalid VLAN range format '{part}'"
+        else:
+            # Validate single vlan
+            try:
+                vlan_id = int(part)
+                if vlan_id < 1 or vlan_id > 4093:
+                    return False, f"VLAN ID '{vlan_id}' must be between 1 and 4093"
+            except ValueError:
+                return False, f"Invalid VLAN ID '{part}'"
+
+    return True, None
+
+
+def validate_vlan_ranges(module):
+    """Validate VLAN range values and required parameters"""
+    state = module.params.get('state')
+    qinq_enabled = module.params.get('qinq_enabled')
+    qinq_vlan = module.params.get('qinq_vlan')
+    native_vlan = module.params.get('native_vlan')
+    allowed_vlans = module.params.get('allowed_vlans')
+
+    if state == 'present':
+        if qinq_enabled:
+            # When qinq_enabled is true, qinq_vlan is required
+            if not qinq_vlan:
+                module.fail_json(msg='missing required arguments: qinq_vlan')
+        else:
+            # When qinq_enabled is false, allowed_vlans is required
+            if not allowed_vlans:
+                module.fail_json(msg='missing required arguments: allowed_vlans')
+
+    if qinq_vlan and (qinq_vlan < 2 or qinq_vlan > 4093):
+        module.fail_json(msg='qinq_vlan must be between 2 and 4093')
+
+    if native_vlan and (native_vlan < 1 or native_vlan > 4093):
+        module.fail_json(msg='native_vlan must be between 1 and 4093')
+
+    # Validate allowed_vlans format if provided and clean it
+    if allowed_vlans:
+        is_valid, error_msg = validate_allowed_vlans_format(allowed_vlans)
+        if not is_valid:
+            module.fail_json(msg=error_msg)
+        # Store the cleaned version (whitespace removed) back to module.params
+        module.params['allowed_vlans'] = allowed_vlans.replace(' ', '')
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        qinq_enabled=dict(type='bool', default=False),  # Verify that placing default works with required_if
+        qinq_vlan=dict(type='int'),
+        native_vlan=dict(type='int'),
+        allowed_vlans=dict(type='str'),
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ['allowed_vlans', 'qinq_vlan'],
+            ['allowed_vlans', 'native_vlan'],
+        ],
+    )
+
+    validate_vlan_ranges(module)
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Resource path used to configure policy
+    resource_path = '/fabric/EthNetworkGroupPolicies'
+
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+
+        # Build VlanSettings based on qinq_enabled
+        vlan_settings = {
+            'QinqEnabled': module.params['qinq_enabled']
+        }
+
+        if module.params['qinq_enabled']:
+            vlan_settings['QinqVlan'] = module.params['qinq_vlan']
+            if module.params['native_vlan']:
+                vlan_settings['NativeVlan'] = module.params['native_vlan']
+        else:
+            # Regular VLAN mode
+            vlan_settings['AllowedVlans'] = module.params['allowed_vlans']
+
+        intersight.api_body.update({
+            'VlanSettings': vlan_settings
+        })
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_ethernet_network_group_policy_info.py
+++ b/plugins/modules/intersight_ethernet_network_group_policy_info.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_ethernet_network_group_policy_info
+short_description: Gather information about Ethernet Network Group Policies in Cisco Intersight
+description:
+  - Gather information about Ethernet Network Group Policies in L(Cisco Intersight,https://intersight.com).
+  - Information can be filtered by O(organization) and O(name).
+  - If no filters are passed, all Ethernet Network Group Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization the Ethernet Network Group Policy belongs to.
+    type: str
+  name:
+    description:
+      - The name of the Ethernet Network Group Policy to gather information from.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Fetch a specific Ethernet Network Group Policy by name
+  cisco.intersight.intersight_ethernet_network_group_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "qinq-policy"
+
+- name: Fetch all Ethernet Network Group Policies in a specific Organization
+  cisco.intersight.intersight_ethernet_network_group_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+
+- name: Fetch all Ethernet Network Group Policies
+  cisco.intersight.intersight_ethernet_network_group_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": [
+    {
+        "Name": "regular-vlans-policy",
+        "ObjectType": "fabric.EthNetworkGroupPolicy",
+        "VlanSettings": {
+            "QinqEnabled": false,
+            "AllowedVlans": "1-8,12,16"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    },
+    {
+        "Name": "qinq-policy",
+        "ObjectType": "fabric.EthNetworkGroupPolicy",
+        "VlanSettings": {
+            "QinqEnabled": true,
+            "QinqVlan": 4,
+            "NativeVlan": 1
+        },
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "DataCenter-A"
+            },
+            {
+                "Key": "Application",
+                "Value": "Database"
+            }
+        ]
+    }
+  ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/fabric/EthNetworkGroupPolicies'
+
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_ethernet_network_group_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_group_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_ethernet_network_group_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_group_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_ethernet_network_group_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_group_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_ethernet_network_group_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_ethernet_network_group_policy/tasks/tests.yml
@@ -1,0 +1,423 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_ethernet_network_group_policy_regular
+      - test_ethernet_network_group_policy_qinq
+      - test_ethernet_network_group_policy_qinq_no_native
+      - test_ethernet_network_group_policy_single_vlan
+      - test_ethernet_network_group_policy_defaults
+      - test_ethernet_network_group_policy_complex_vlans
+      - test_ethernet_network_group_policy_whitespace_vlans
+
+  - name: Create ethernet network group policy with regular VLANs - check-mode
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+      description: "Test ethernet network group policy with regular VLANs"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      qinq_enabled: false
+      allowed_vlans: "1-8,12,16"
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify ethernet network group policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response == {}
+
+  - name: Create ethernet network group policy with regular VLANs
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+      description: "Test ethernet network group policy with regular VLANs"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      qinq_enabled: false
+      allowed_vlans: "1-8,12,16"
+    register: creation_res_regular
+
+  - name: Fetch info after regular VLANs policy creation
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+    register: creation_info_res_regular
+
+  - name: Verify ethernet network group policy creation with regular VLANs by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_regular.changed
+        - creation_info_res_regular.api_response[0].Name == 'test_ethernet_network_group_policy_regular'
+        - creation_info_res_regular.api_response[0].VlanSettings.QinqEnabled == false
+        - creation_info_res_regular.api_response[0].VlanSettings.AllowedVlans == '1-8,12,16'
+
+  - name: Verify ethernet network group policy creation response aligns with info response
+    ansible.builtin.assert:
+      that:
+        - creation_res_regular.api_response.Name == creation_info_res_regular.api_response[0].Name
+        - creation_res_regular.api_response.VlanSettings.QinqEnabled == creation_info_res_regular.api_response[0].VlanSettings.QinqEnabled
+        - creation_res_regular.api_response.VlanSettings.AllowedVlans == creation_info_res_regular.api_response[0].VlanSettings.AllowedVlans
+
+  - name: Create ethernet network group policy with regular VLANs (idempotency check)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+      description: "Test ethernet network group policy with regular VLANs"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      qinq_enabled: false
+      allowed_vlans: "1-8,12,16"
+    register: creation_res_regular_ide
+
+  - name: Verify ethernet network group policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not creation_res_regular_ide.changed
+
+  - name: Change allowed VLANs on existing ethernet network group policy
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+      qinq_enabled: false
+      allowed_vlans: "1-10,20-30"
+    register: changed_res_regular
+
+  - name: Fetch info after regular VLANs policy change
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_regular
+    register: change_info_res_regular
+
+  - name: Verify ethernet network group policy change by info
+    ansible.builtin.assert:
+      that:
+        - changed_res_regular.changed
+        - change_info_res_regular.api_response[0].Name == 'test_ethernet_network_group_policy_regular'
+        - change_info_res_regular.api_response[0].VlanSettings.AllowedVlans == '1-10,20-30'
+
+  - name: Create ethernet network group policy with QinQ enabled (with native VLAN)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_qinq
+      description: "Test ethernet network group policy with QinQ enabled"
+      tags:
+        - Key: Type
+          Value: QinQ
+      qinq_enabled: true
+      qinq_vlan: 4
+      native_vlan: 1
+    register: creation_res_qinq
+
+  - name: Fetch info after QinQ policy creation
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_qinq
+    register: creation_info_res_qinq
+
+  - name: Verify ethernet network group policy creation with QinQ by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_qinq.changed
+        - creation_info_res_qinq.api_response[0].Name == 'test_ethernet_network_group_policy_qinq'
+        - creation_info_res_qinq.api_response[0].VlanSettings.QinqEnabled == true
+        - creation_info_res_qinq.api_response[0].VlanSettings.QinqVlan == 4
+        - creation_info_res_qinq.api_response[0].VlanSettings.NativeVlan == 1
+
+  - name: Create ethernet network group policy with QinQ enabled (no native VLAN)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_qinq_no_native
+      description: "Test ethernet network group policy with QinQ enabled (no native VLAN)"
+      qinq_enabled: true
+      qinq_vlan: 100
+    register: creation_res_qinq_no_native
+
+  - name: Fetch info after QinQ policy creation (no native VLAN)
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_qinq_no_native
+    register: creation_info_res_qinq_no_native
+
+  - name: Verify ethernet network group policy creation with QinQ (no native VLAN) by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_qinq_no_native.changed
+        - creation_info_res_qinq_no_native.api_response[0].Name == 'test_ethernet_network_group_policy_qinq_no_native'
+        - creation_info_res_qinq_no_native.api_response[0].VlanSettings.QinqEnabled == true
+        - creation_info_res_qinq_no_native.api_response[0].VlanSettings.QinqVlan == 100
+        - creation_info_res_qinq_no_native.api_response[0].VlanSettings.NativeVlan == 0 # Native vlan is set to 0 when not set
+
+  - name: Create ethernet network group policy with single VLAN
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_single_vlan
+      description: "Test ethernet network group policy with single VLAN"
+      qinq_enabled: false
+      allowed_vlans: "50"
+    register: creation_res_single
+
+  - name: Fetch info after single VLAN policy creation
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_single_vlan
+    register: creation_info_res_single
+
+  - name: Verify ethernet network group policy creation with single VLAN by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_single.changed
+        - creation_info_res_single.api_response[0].Name == 'test_ethernet_network_group_policy_single_vlan'
+        - creation_info_res_single.api_response[0].VlanSettings.QinqEnabled == false
+        - creation_info_res_single.api_response[0].VlanSettings.AllowedVlans == '50'
+
+  - name: Create ethernet network group policy with defaults (only name specified)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_defaults
+      description: "Test ethernet network group policy with default values"
+      qinq_enabled: false
+      allowed_vlans: "1"
+    register: creation_res_defaults
+
+  - name: Create ethernet network group policy with complex allowed VLANs format
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_complex_vlans
+      description: "Test ethernet network group policy with complex VLAN format"
+      qinq_enabled: false
+      allowed_vlans: "10-15,25,30-35,100"
+    register: creation_res_complex_vlans
+
+  - name: Fetch info after complex VLANs policy creation
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_complex_vlans
+    register: creation_info_res_complex_vlans
+
+  - name: Verify ethernet network group policy creation with complex VLANs by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_complex_vlans.changed
+        - creation_info_res_complex_vlans.api_response[0].Name == 'test_ethernet_network_group_policy_complex_vlans'
+        - creation_info_res_complex_vlans.api_response[0].VlanSettings.QinqEnabled == false
+        - creation_info_res_complex_vlans.api_response[0].VlanSettings.AllowedVlans == '10-15,25,30-35,100'
+
+  - name: Create ethernet network group policy with allowed VLANs containing whitespace
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_whitespace_vlans
+      description: "Test ethernet network group policy with whitespace in VLAN format"
+      qinq_enabled: false
+      allowed_vlans: " 1 - 5 , 10 , 15 - 20 "
+    register: creation_res_whitespace_vlans
+
+  - name: Fetch info after whitespace VLANs policy creation
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_whitespace_vlans
+    register: creation_info_res_whitespace_vlans
+
+  - name: Verify ethernet network group policy creation with whitespace VLANs by info
+    ansible.builtin.assert:
+      that:
+        - creation_res_whitespace_vlans.changed
+        - creation_info_res_whitespace_vlans.api_response[0].Name == 'test_ethernet_network_group_policy_whitespace_vlans'
+        - creation_info_res_whitespace_vlans.api_response[0].VlanSettings.QinqEnabled == false
+        - creation_info_res_whitespace_vlans.api_response[0].VlanSettings.AllowedVlans == '1-5,10,15-20'
+
+  - name: Fetch info for defaults policy
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_group_policy_defaults
+    register: defaults_info_res
+
+  - name: Verify ethernet network group policy defaults are applied correctly
+    ansible.builtin.assert:
+      that:
+        - creation_res_defaults.changed
+        - defaults_info_res.api_response[0].Name == 'test_ethernet_network_group_policy_defaults'
+        - defaults_info_res.api_response[0].VlanSettings.QinqEnabled == false
+        - defaults_info_res.api_response[0].VlanSettings.AllowedVlans == '1'
+
+  - name: Fetch all ethernet network group policies under selected organization
+    cisco.intersight.intersight_ethernet_network_group_policy_info:
+      <<: *api_info
+    register: creation_info_res_all
+
+  - name: Check that there are at least 7 ethernet network group policies under this organization
+    ansible.builtin.assert:
+      that:
+        - creation_info_res_all.api_response | length >= 7
+
+  # Test parameter validation failures
+  - name: Test parameter validation - QinQ enabled without QinQ VLAN
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_qinq_missing_vlan
+      qinq_enabled: true
+      state: present
+    register: qinq_missing_vlan_res
+    failed_when:
+      - "'missing required arguments: qinq_vlan' not in qinq_missing_vlan_res.msg"
+
+  - name: Test parameter validation - QinQ disabled without allowed VLANs
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_qinq_disabled_no_vlans
+      qinq_enabled: false
+      state: present
+    register: qinq_disabled_no_vlans_res
+    failed_when:
+      - "'missing required arguments: allowed_vlans' not in qinq_disabled_no_vlans_res.msg"
+
+  - name: Test parameter validation - QinQ enabled with allowed VLANs
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_qinq_with_allowed_vlans
+      qinq_enabled: true
+      qinq_vlan: 100
+      allowed_vlans: "1-10"
+    register: qinq_with_allowed_vlans_res
+    failed_when:
+      - "'parameters are mutually exclusive: allowed_vlans|qinq_vlan' not in qinq_with_allowed_vlans_res.msg"
+
+  - name: Test parameter validation - QinQ disabled with QinQ VLAN
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_qinq_disabled_with_qinq_vlan
+      qinq_enabled: false
+      qinq_vlan: 100
+      allowed_vlans: "1-10"
+    register: qinq_disabled_with_qinq_vlan_res
+    failed_when:
+      - "'parameters are mutually exclusive: allowed_vlans|qinq_vlan' not in qinq_disabled_with_qinq_vlan_res.msg"
+
+  - name: Test parameter validation - Invalid QinQ VLAN (too high)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_qinq_vlan_high
+      qinq_enabled: true
+      qinq_vlan: 5000
+    register: invalid_qinq_vlan_high_res
+    failed_when:
+      - "'qinq_vlan must be between 2 and 4093' not in invalid_qinq_vlan_high_res.msg"
+
+  - name: Test parameter validation - Native VLAN with allowed VLANs
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_native_vlan_with_allowed_vlans
+      qinq_enabled: false
+      native_vlan: 100
+      allowed_vlans: "1-10"
+    register: native_vlan_with_allowed_vlans_res
+    failed_when:
+      - "'parameters are mutually exclusive: allowed_vlans|native_vlan' not in native_vlan_with_allowed_vlans_res.msg"
+
+  - name: Test parameter validation - Invalid allowed VLANs format (incomplete range)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_incomplete_range
+      qinq_enabled: false
+      allowed_vlans: "1-"
+    register: invalid_allowed_vlans_incomplete_range_res
+    failed_when:
+      - "'allowed_vlans must be in format' not in invalid_allowed_vlans_incomplete_range_res.msg"
+
+  - name: Test parameter validation - Invalid allowed VLANs format (letters)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_letters
+      qinq_enabled: false
+      allowed_vlans: "a,b,c"
+    register: invalid_allowed_vlans_letters_res
+    failed_when:
+      - "'allowed_vlans must be in format' not in invalid_allowed_vlans_letters_res.msg"
+
+  - name: Test parameter validation - Invalid allowed VLANs format (trailing comma)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_trailing_comma
+      qinq_enabled: false
+      allowed_vlans: "1,2,3,"
+    register: invalid_allowed_vlans_trailing_comma_res
+    failed_when:
+      - "'allowed_vlans must be in format' not in invalid_allowed_vlans_trailing_comma_res.msg"
+
+  - name: Test parameter validation - Invalid allowed VLANs range (start >= end)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_bad_range
+      qinq_enabled: false
+      allowed_vlans: "5-3"
+    register: invalid_allowed_vlans_bad_range_res
+    failed_when:
+      - "'start must be less than end' not in invalid_allowed_vlans_bad_range_res.msg"
+
+  - name: Test parameter validation - invalid allowed VLANs (VLAN ID too high)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_high_id
+      qinq_enabled: false
+      allowed_vlans: "1,5000"
+    register: invalid_allowed_vlans_high_id_res
+    failed_when:
+      - "'must be between 1 and 4093' not in invalid_allowed_vlans_high_id_res.msg"
+
+  - name: Test parameter validation - Invalid allowed VLANs (VLAN ID too low)
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_low_id
+      qinq_enabled: false
+      allowed_vlans: "0,10"
+    register: invalid_allowed_vlans_low_id_res
+    failed_when:
+      - "'must be between 1 and 4093' not in invalid_allowed_vlans_low_id_res.msg"
+
+  - name: Test parameter validation - Empty allowed VLANs
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: test_invalid_allowed_vlans_empty
+      qinq_enabled: false
+      allowed_vlans: ""
+    register: invalid_allowed_vlans_empty_res
+    failed_when:
+      - "'missing required arguments: allowed_vlans' not in invalid_allowed_vlans_empty_res.msg"
+
+  always:
+  - name: Remove ethernet network group policies
+    cisco.intersight.intersight_ethernet_network_group_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_ethernet_network_group_policy_regular
+      - test_ethernet_network_group_policy_qinq
+      - test_ethernet_network_group_policy_qinq_no_native
+      - test_ethernet_network_group_policy_single_vlan
+      - test_ethernet_network_group_policy_defaults
+      - test_ethernet_network_group_policy_complex_vlans
+      - test_ethernet_network_group_policy_whitespace_vlans


### PR DESCRIPTION
#### SUMMARY
- Create  ethernet_network_group policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ ethernet_network_group_policy.py
- plugins/modules/intersight_ethernet_network_group_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests