### PR TITLE
Introduce ethernet_network_control_policy

### DIFF
--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -379,6 +379,10 @@ class IntersightModule():
                     # return the 1st element in the results list
                     self.result['api_response'] = response_dict['Results'][0]
                     self.result['trace_id'] = response_dict.get('trace_id')
+                elif response_dict and 'Moid' in response_dict:
+                    # PATCH returned the updated object directly (not in Results array)
+                    self.result['api_response'] = response_dict
+                    self.result['trace_id'] = response_dict.get('trace_id')
             else:
                 # create the resource
                 options = {

--- a/plugins/modules/intersight_ethernet_network_control_policy.py
+++ b/plugins/modules/intersight_ethernet_network_control_policy.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_ethernet_network_control_policy
+short_description: Ethernet Network Control Policy configuration for Cisco Intersight
+description:
+  - Manages Ethernet Network Control Policy configuration on Cisco Intersight.
+  - A policy to configure network control settings for ethernet connections on Cisco Intersight managed servers.
+  - This policy is applicable only for UCS Servers (FI-Attached).
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/fabric/EthNetworkControlPolicy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles, Policies, and Pools that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Ethernet Network Control Policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Ethernet Network Control Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  cdp_enabled:
+    description:
+      - Enables the CDP on an interface.
+      - Cisco Discovery Protocol (CDP) is a proprietary Data Link Layer protocol developed by Cisco Systems.
+    type: bool
+    default: false
+  mac_registration_mode:
+    description:
+      - Determines the MAC addresses that have to be registered with the switch.
+      - nativeVlanOnly - Register only the MAC addresses learned in the native VLAN.
+      - allVlans - Register the MAC addresses learned in all VLANs.
+    type: str
+    choices: ['nativeVlanOnly', 'allVlans']
+    default: 'nativeVlanOnly'
+  uplink_fail_action:
+    description:
+      - Determines the state of the virtual interface (vethernet / vfc) on the switch when a suitable uplink is not pinned.
+      - linkDown - The vethernet will go down.
+      - warning - The vethernet will remain up and will not fail over if uplink connectivity is lost.
+      - "Important! If the Action on Uplink is set to Warning, the switch will not fail over if uplink connectivity is lost."
+    type: str
+    choices: ['linkDown', 'warning']
+    default: 'linkDown'
+  forge_mac:
+    description:
+      - Determines if the MAC forging is allowed or denied on an interface.
+      - allow - Allows MAC forging on the interface.
+      - deny - Denies MAC forging on the interface.
+    type: str
+    choices: ['allow', 'deny']
+    default: 'allow'
+  lldp_transmit_enabled:
+    description:
+      - Determines if the LLDP frames can be transmitted by an interface on the switch.
+      - Link Layer Discovery Protocol (LLDP) is a vendor-neutral link layer protocol.
+    type: bool
+    default: false
+  lldp_receive_enabled:
+    description:
+      - Determines if the LLDP frames can be received by an interface on the switch.
+      - Link Layer Discovery Protocol (LLDP) is a vendor-neutral link layer protocol.
+    type: bool
+    default: false
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create an Ethernet Network Control Policy with default settings
+  cisco.intersight.intersight_ethernet_network_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "default-network-control-policy"
+    description: "Default Ethernet Network Control policy"
+    state: present
+
+- name: Create an Ethernet Network Control Policy with CDP and LLDP enabled
+  cisco.intersight.intersight_ethernet_network_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "discovery-enabled-policy"
+    description: "Network Control policy with discovery protocols enabled"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+    cdp_enabled: true
+    mac_registration_mode: "allVlans"
+    uplink_fail_action: "warning"
+    forge_mac: "deny"
+    lldp_transmit_enabled: true
+    lldp_receive_enabled: true
+    state: present
+
+- name: Create an Ethernet Network Control Policy with strict security settings
+  cisco.intersight.intersight_ethernet_network_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "secure-network-control-policy"
+    description: "Secure Network Control policy with MAC forging denied"
+    cdp_enabled: false
+    mac_registration_mode: "nativeVlanOnly"
+    uplink_fail_action: "linkDown"
+    forge_mac: "deny"
+    lldp_transmit_enabled: false
+    lldp_receive_enabled: false
+    state: present
+
+- name: Delete an Ethernet Network Control Policy
+  cisco.intersight.intersight_ethernet_network_control_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "secure-network-control-policy"
+    state: absent
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "discovery-enabled-policy",
+        "ObjectType": "fabric.EthNetworkControlPolicy",
+        "CdpEnabled": true,
+        "MacRegistrationMode": "allVlans",
+        "UplinkFailAction": "warning",
+        "ForgeMac": "deny",
+        "LldpSettings": {
+            "TransmitEnabled": true,
+            "ReceiveEnabled": true
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        cdp_enabled=dict(type='bool', default=False),
+        mac_registration_mode=dict(
+            type='str',
+            choices=['nativeVlanOnly', 'allVlans'],
+            default='nativeVlanOnly'
+        ),
+        uplink_fail_action=dict(
+            type='str',
+            choices=['linkDown', 'warning'],
+            default='linkDown'
+        ),
+        forge_mac=dict(
+            type='str',
+            choices=['allow', 'deny'],
+            default='allow'
+        ),
+        lldp_transmit_enabled=dict(type='bool', default=False),
+        lldp_receive_enabled=dict(type='bool', default=False),
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Resource path used to configure policy
+    resource_path = '/fabric/EthNetworkControlPolicies'
+
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+
+        intersight.api_body['CdpEnabled'] = module.params['cdp_enabled']
+        intersight.api_body['MacRegistrationMode'] = module.params['mac_registration_mode']
+        intersight.api_body['UplinkFailAction'] = module.params['uplink_fail_action']
+        intersight.api_body['ForgeMac'] = module.params['forge_mac']
+        intersight.api_body['LldpSettings'] = {
+            'TransmitEnabled': module.params['lldp_transmit_enabled'],
+            'ReceiveEnabled': module.params['lldp_receive_enabled']
+        }
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_ethernet_network_control_policy_info.py
+++ b/plugins/modules/intersight_ethernet_network_control_policy_info.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_ethernet_network_control_policy_info
+short_description: Gather information about Ethernet Network Control Policies in Cisco Intersight
+description:
+  - Gather information about Ethernet Network Control Policies in L(Cisco Intersight,https://intersight.com).
+  - Information can be filtered by O(organization) and O(name).
+  - If no filters are passed, all Ethernet Network Control Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization the Ethernet Network Control Policy belongs to.
+    type: str
+  name:
+    description:
+      - The name of the Ethernet Network Control Policy to gather information from.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Fetch a specific Ethernet Network Control Policy by name
+  cisco.intersight.intersight_ethernet_network_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "discovery-enabled-policy"
+
+- name: Fetch all Ethernet Network Control Policies in a specific Organization
+  cisco.intersight.intersight_ethernet_network_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+
+- name: Fetch all Ethernet Network Control Policies
+  cisco.intersight.intersight_ethernet_network_control_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+'''
+
+RETURN = r'''
+api_repsonse:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": [
+    {
+        "Name": "default-network-control-policy",
+        "ObjectType": "fabric.EthNetworkControlPolicy",
+        "CdpEnabled": false,
+        "MacRegistrationMode": "nativeVlanOnly",
+        "UplinkFailAction": "linkDown",
+        "ForgeMac": "allow",
+        "LldpSettings": {
+            "TransmitEnabled": false,
+            "ReceiveEnabled": false
+        },
+        "Tags": [
+            {
+                "Key": "Site",
+                "Value": "DataCenter-A"
+            },
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    },
+    {
+        "Name": "discovery-enabled-policy",
+        "ObjectType": "fabric.EthNetworkControlPolicy",
+        "CdpEnabled": true,
+        "MacRegistrationMode": "allVlans",
+        "UplinkFailAction": "warning",
+        "ForgeMac": "deny",
+        "LldpSettings": {
+            "TransmitEnabled": true,
+            "ReceiveEnabled": true
+        },
+        "Tags": [
+            {
+                "Key": "Priority",
+                "Value": "High"
+            },
+            {
+                "Key": "Application",
+                "Value": "Networking"
+            }
+        ]
+    }
+  ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/fabric/EthNetworkControlPolicies'
+
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_ethernet_network_control_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_control_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_ethernet_network_control_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_control_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run 

--- a/tests/integration/targets/intersight_ethernet_network_control_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_ethernet_network_control_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml 

--- a/tests/integration/targets/intersight_ethernet_network_control_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_ethernet_network_control_policy/tasks/tests.yml
@@ -1,0 +1,226 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_ethernet_network_control_policy
+      - test_ethernet_network_control_policy_2
+      - test_ethernet_network_control_policy_discovery
+      - test_ethernet_network_control_policy_defaults
+
+  - name: Create ethernet network control policy - check-mode
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy
+      description: "Test ethernet network control policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      cdp_enabled: false
+      mac_registration_mode: "nativeVlanOnly"
+      uplink_fail_action: "linkDown"
+      forge_mac: "allow"
+      lldp_transmit_enabled: false
+      lldp_receive_enabled: false
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify ethernet network control policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response == {}
+
+  - name: Create ethernet network control policy
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy
+      description: "Test ethernet network control policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      cdp_enabled: false
+      mac_registration_mode: "nativeVlanOnly"
+      uplink_fail_action: "linkDown"
+      forge_mac: "allow"
+      lldp_transmit_enabled: false
+      lldp_receive_enabled: false
+    register: creation_res
+
+  - name: Verify ethernet network control policy was created
+    ansible.builtin.assert:
+      that:
+        - creation_res is changed
+        - creation_res.api_response.Name == "test_ethernet_network_control_policy"
+        - creation_res.api_response.CdpEnabled == false
+        - creation_res.api_response.MacRegistrationMode == "nativeVlanOnly"
+        - creation_res.api_response.UplinkFailAction == "linkDown"
+        - creation_res.api_response.ForgeMac == "allow"
+        - creation_res.api_response.LldpSettings.TransmitEnabled == false
+        - creation_res.api_response.LldpSettings.ReceiveEnabled == false
+
+  - name: Create ethernet network control policy - idempotent
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy
+      description: "Test ethernet network control policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Test
+      cdp_enabled: false
+      mac_registration_mode: "nativeVlanOnly"
+      uplink_fail_action: "linkDown"
+      forge_mac: "allow"
+      lldp_transmit_enabled: false
+      lldp_receive_enabled: false
+    register: creation_res_idem
+
+  - name: Verify ethernet network control policy creation was idempotent
+    ansible.builtin.assert:
+      that:
+        - creation_res_idem is not changed
+
+  - name: Update ethernet network control policy
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy
+      description: "Updated ethernet network control policy description"
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Environment
+          Value: Production
+      cdp_enabled: true
+      mac_registration_mode: "allVlans"
+      uplink_fail_action: "warning"
+      forge_mac: "deny"
+      lldp_transmit_enabled: true
+      lldp_receive_enabled: true
+    register: update_res
+
+  - name: Verify ethernet network control policy was updated
+    ansible.builtin.assert:
+      that:
+        - update_res is changed
+        - update_res.api_response.Name == "test_ethernet_network_control_policy"
+        - update_res.api_response.CdpEnabled == true
+        - update_res.api_response.MacRegistrationMode == "allVlans"
+        - update_res.api_response.UplinkFailAction == "warning"
+        - update_res.api_response.ForgeMac == "deny"
+        - update_res.api_response.LldpSettings.TransmitEnabled == true
+        - update_res.api_response.LldpSettings.ReceiveEnabled == true
+
+  - name: Create ethernet network control policy with discovery protocols enabled
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy_discovery
+      description: "Test ethernet network control policy with discovery protocols"
+      cdp_enabled: true
+      mac_registration_mode: "allVlans"
+      uplink_fail_action: "warning"
+      forge_mac: "deny"
+      lldp_transmit_enabled: true
+      lldp_receive_enabled: true
+    register: discovery_policy_res
+
+  - name: Verify discovery-enabled ethernet network control policy was created
+    ansible.builtin.assert:
+      that:
+        - discovery_policy_res is changed
+        - discovery_policy_res.api_response.Name == "test_ethernet_network_control_policy_discovery"
+        - discovery_policy_res.api_response.CdpEnabled == true
+        - discovery_policy_res.api_response.MacRegistrationMode == "allVlans"
+        - discovery_policy_res.api_response.UplinkFailAction == "warning"
+        - discovery_policy_res.api_response.ForgeMac == "deny"
+        - discovery_policy_res.api_response.LldpSettings.TransmitEnabled == true
+        - discovery_policy_res.api_response.LldpSettings.ReceiveEnabled == true
+
+  - name: Create ethernet network control policy with defaults
+    cisco.intersight.intersight_ethernet_network_control_policy:
+      <<: *api_info
+      name: test_ethernet_network_control_policy_defaults
+      description: "Test ethernet network control policy with default values"
+    register: defaults_policy_res
+
+  - name: Verify default ethernet network control policy was created
+    ansible.builtin.assert:
+      that:
+        - defaults_policy_res is changed
+        - defaults_policy_res.api_response.Name == "test_ethernet_network_control_policy_defaults"
+        - defaults_policy_res.api_response.CdpEnabled == false
+        - defaults_policy_res.api_response.MacRegistrationMode == "nativeVlanOnly"
+        - defaults_policy_res.api_response.UplinkFailAction == "linkDown"
+        - defaults_policy_res.api_response.ForgeMac == "allow"
+        - defaults_policy_res.api_response.LldpSettings.TransmitEnabled == false
+        - defaults_policy_res.api_response.LldpSettings.ReceiveEnabled == false
+
+  - name: Get all ethernet network control policies
+    cisco.intersight.intersight_ethernet_network_control_policy_info:
+      <<: *api_info
+    register: all_policies
+
+  - name: Verify all policies were returned
+    ansible.builtin.assert:
+      that:
+        - all_policies.api_response | length >= 3
+        - all_policies.api_response | selectattr('Name', 'equalto', 'test_ethernet_network_control_policy') | list | length == 1
+        - all_policies.api_response | selectattr('Name', 'equalto', 'test_ethernet_network_control_policy_discovery') | list | length == 1
+        - all_policies.api_response | selectattr('Name', 'equalto', 'test_ethernet_network_control_policy_defaults') | list | length == 1
+
+  - name: Get specific ethernet network control policy by name
+    cisco.intersight.intersight_ethernet_network_control_policy_info:
+      <<: *api_info
+      name: test_ethernet_network_control_policy
+    register: specific_policy
+
+  - name: Verify specific policy was returned
+    ansible.builtin.assert:
+      that:
+        - specific_policy.api_response | length == 1
+        - specific_policy.api_response[0].Name == "test_ethernet_network_control_policy"
+        - specific_policy.api_response[0].CdpEnabled == true
+        - specific_policy.api_response[0].MacRegistrationMode == "allVlans"
+        - specific_policy.api_response[0].UplinkFailAction == "warning"
+        - specific_policy.api_response[0].ForgeMac == "deny"
+        - specific_policy.api_response[0].LldpSettings.TransmitEnabled == true
+        - specific_policy.api_response[0].LldpSettings.ReceiveEnabled == true
+
+  - name: Get ethernet network control policies by organization
+    cisco.intersight.intersight_ethernet_network_control_policy_info:
+      <<: *api_info
+    register: org_policies
+
+  - name: Verify organization policies were returned
+    ansible.builtin.assert:
+      that:
+        - org_policies.api_response | length >= 3
+
+  always:
+    - name: Clean up all test policies
+      cisco.intersight.intersight_ethernet_network_control_policy:
+        <<: *api_info
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - test_ethernet_network_control_policy
+        - test_ethernet_network_control_policy_2
+        - test_ethernet_network_control_policy_discovery
+        - test_ethernet_network_control_policy_defaults


### PR DESCRIPTION
#### SUMMARY
- Create  ethernet_network_control_policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ ethernet_network_control_policy.py
- plugins/modules/intersight_ethernet_network_control_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests
- Added a fix - response after updating an existing resource, was returned with pre updated values.
