### PR TITLE
Introduce iscasi static target policy

### DIFF
--- a/plugins/modules/intersight_iscsi_static_target_policy.py
+++ b/plugins/modules/intersight_iscsi_static_target_policy.py
@@ -1,0 +1,263 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_iscsi_static_target_policy
+short_description: Manage iSCSI Static Target Policies for Cisco Intersight
+description:
+  - Create, update, and delete iSCSI Static Target Policies on Cisco Intersight.
+  - iSCSI static target policy enables you to configure the iSCSI targets for iSCSI vNIC interfaces.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/vnic/IscsiStaticTargetPolicy/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the iSCSI Static Target Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the iSCSI Static Target Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  target_name:
+    description:
+      - Qualified Name (IQN) or Extended Unique Identifier (EUI) name of the iSCSI target.
+      - This is the name that uniquely identifies the target in the iSCSI network.
+      - Example IQN format - iqn.1991-05.com.microsoft:winclient1
+      - Example EUI format - eui.02004567A425678D
+      - Required when state is present.
+    type: str
+  port:
+    description:
+      - The port associated with the iSCSI target.
+      - Valid range is 1-65535.
+      - Common iSCSI port is 3260.
+      - Required when state is present.
+    type: int
+  lun_id:
+    description:
+      - The Logical Unit Number (LUN) Identifier for the iSCSI target.
+      - Valid values are 0 or greater (typically 0-255).
+      - Required when state is present.
+    type: int
+  ip_protocol:
+    description:
+      - Type of the IP address requested for iSCSI vNIC.
+      - IPv4 or IPv6.
+      - Required when state is present.
+    type: str
+    choices: ['IPv4', 'IPv6']
+  ipv4_address:
+    description:
+      - The IPv4 address assigned to the iSCSI target.
+      - Required when ip_protocol is IPv4 and state is present.
+    type: str
+  ipv6_address:
+    description:
+      - The IPv6 address assigned to the iSCSI target.
+      - Required when ip_protocol is IPv6 and state is present.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create an iSCSI Static Target Policy with IPv4
+  cisco.intersight.intersight_iscsi_static_target_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-static-target-policy-01"
+    description: "iSCSI static target policy for production servers"
+    target_name: "iqn.1991-05.com.microsoft:winclient1"
+    port: 3260
+    lun_id: 0
+    ip_protocol: "IPv4"
+    ipv4_address: "192.168.10.100"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+      - Key: "Owner"
+        Value: "Storage-Team"
+    state: present
+
+- name: Create an iSCSI Static Target Policy with IPv6
+  cisco.intersight.intersight_iscsi_static_target_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-static-target-policy-ipv6"
+    description: "iSCSI static target policy with IPv6 addressing"
+    target_name: "iqn.2001-04.com.example:storage.disk2"
+    port: 3260
+    lun_id: 1
+    ip_protocol: "IPv6"
+    ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    state: present
+
+- name: Update an existing iSCSI Static Target Policy
+  cisco.intersight.intersight_iscsi_static_target_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "iscsi-static-target-policy-01"
+    description: "Updated description for iSCSI target policy"
+    target_name: "iqn.1991-05.com.microsoft:winclient1"
+    port: 3260
+    lun_id: 2
+    ip_protocol: "IPv4"
+    ipv4_address: "192.168.10.101"
+    state: present
+
+- name: Delete an iSCSI Static Target Policy
+  cisco.intersight.intersight_iscsi_static_target_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "iscsi-static-target-policy-01"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "iscsi-static-target-policy-01",
+        "ObjectType": "vnic.IscsiStaticTargetPolicy",
+        "Moid": "1234567890abcdef12345678",
+        "TargetName": "iqn.1991-05.com.microsoft:winclient1",
+        "Port": 3260,
+        "Lun": {
+            "LunId": 0
+        },
+        "IscsiIpType": "IPv4",
+        "IpAddress": "192.168.10.100",
+        "Organization": {
+            "Moid": "abcdef1234567890abcdef12",
+            "ObjectType": "organization.Organization"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        target_name=dict(type='str'),
+        port=dict(type='int'),
+        lun_id=dict(type='int'),
+        ip_protocol=dict(type='str', choices=['IPv4', 'IPv6']),
+        ipv4_address=dict(type='str'),
+        ipv6_address=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'present', ['target_name', 'port', 'lun_id', 'ip_protocol']],
+            ['ip_protocol', 'IPv4', ['ipv4_address']],
+            ['ip_protocol', 'IPv6', ['ipv6_address']]
+        ],
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Validate port range (1-65535)
+    if module.params['state'] == 'present' and module.params.get('port'):
+        port = module.params['port']
+        if port < 1 or port > 65535:
+            module.fail_json(msg=f"Port must be between 1 and 65535. Provided value: {port}")
+
+    # Validate LUN ID (>= 0)
+    if module.params['state'] == 'present' and module.params.get('lun_id') is not None:
+        lun_id = module.params['lun_id']
+        if lun_id < 0:
+            module.fail_json(msg=f"LUN ID must be 0 or greater. Provided value: {lun_id}")
+
+    # Resource path used to configure policy
+    resource_path = '/vnic/IscsiStaticTargetPolicies'
+
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+
+    # Add fields for present state
+    if intersight.module.params['state'] == 'present':
+        intersight.api_body['TargetName'] = intersight.module.params['target_name']
+        intersight.api_body['Port'] = intersight.module.params['port']
+        intersight.api_body['Lun'] = {
+            'LunId': intersight.module.params['lun_id']
+        }
+        intersight.api_body['IscsiIpType'] = intersight.module.params['ip_protocol']
+
+        # Add IP address based on protocol type
+        if intersight.module.params['ip_protocol'] == 'IPv4':
+            intersight.api_body['IpAddress'] = intersight.module.params['ipv4_address']
+        elif intersight.module.params['ip_protocol'] == 'IPv6':
+            intersight.api_body['IpAddress'] = intersight.module.params['ipv6_address']
+
+        intersight.set_tags_and_description()
+
+    # Configure the policy
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_iscsi_static_target_policy_info.py
+++ b/plugins/modules/intersight_iscsi_static_target_policy_info.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_iscsi_static_target_policy_info
+short_description: Gather information about iSCSI Static Target Policies in Cisco Intersight
+description:
+  - Retrieve information about iSCSI Static Target Policies from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization or policy name.
+  - Returns structured data with policy metadata and iSCSI target configuration details.
+  - If no filters are provided, all iSCSI Static Target Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter iSCSI Static Target Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the iSCSI Static Target Policy to retrieve information from.
+      - When specified, only the matching policy will be returned.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all iSCSI Static Target Policies from all organizations
+  cisco.intersight.intersight_iscsi_static_target_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_iscsi_policies
+
+# Organization-specific Examples
+- name: Fetch all iSCSI Static Target Policies from the default organization
+  cisco.intersight.intersight_iscsi_static_target_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all iSCSI Static Target Policies from a custom organization
+  cisco.intersight.intersight_iscsi_static_target_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific iSCSI Static Target Policy by name
+  cisco.intersight.intersight_iscsi_static_target_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "iscsi-static-target-policy-01"
+  register: specific_policy
+
+- name: Fetch a specific policy from a specific organization
+  cisco.intersight.intersight_iscsi_static_target_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Production"
+    name: "iscsi-static-target-policy-prod"
+  register: specific_org_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing iSCSI Static Target Policy information.
+    - Returns a dictionary when querying a single policy or no policies found.
+    - Returns a list when multiple policies are found.
+  returned: always
+  type: dict
+  sample:
+    # Single policy response (when name parameter is used or only one policy found)
+    Name: "iscsi-static-target-policy-01"
+    ObjectType: "vnic.IscsiStaticTargetPolicy"
+    Moid: "1234567890abcdef12345678"
+    Description: "iSCSI static target policy for production servers"
+    TargetName: "iqn.1991-05.com.microsoft:winclient1"
+    Port: 3260
+    Lun:
+      LunId: 0
+    IscsiIpType: "IPv4"
+    IpAddress: "192.168.10.100"
+    Organization:
+      Name: "default"
+      ObjectType: "organization.Organization"
+      Moid: "abcdef1234567890abcdef12"
+    Tags:
+      - Key: "Environment"
+        Value: "Production"
+      - Key: "Owner"
+        Value: "Storage-Team"
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+
+    # Resource path used to fetch policy info
+    resource_path = '/vnic/IscsiStaticTargetPolicies'
+
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+
+    # Reset api_response before the API call to avoid previous responses
+    intersight.result['api_response'] = {}
+
+    # Get iSCSI Static Target policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    policies = intersight.result.get('api_response', [])
+
+    # Create final response structure
+    final_api_response = None
+
+    # Ensure policies is always a list for iteration, even if a single dict is returned
+    if isinstance(policies, dict):
+        policies = [policies]
+    elif not isinstance(policies, list):
+        policies = []
+
+    # Set final response based on number of policies found
+    if len(policies) == 1:
+        # Single policy - return as dict
+        final_api_response = policies[0]
+    elif len(policies) > 1:
+        # Multiple policies - return as list
+        final_api_response = policies
+    else:
+        # No policies found - return empty structure
+        final_api_response = {}
+
+    # Use intersight.result and update api_response directly
+    intersight.result['api_response'] = final_api_response
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_iscsi_static_target_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_iscsi_static_target_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_iscsi_static_target_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_iscsi_static_target_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_run

--- a/tests/integration/targets/intersight_iscsi_static_target_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_iscsi_static_target_policy/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Run iSCSI Static Target Policy tests
+  ansible.builtin.include_tasks: tests.yml

--- a/tests/integration/targets/intersight_iscsi_static_target_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_iscsi_static_target_policy/tasks/tests.yml
@@ -1,0 +1,301 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_iscsi_policy
+      - test_iscsi_policy_2
+      - test_iscsi_policy_minimal
+      - test_iscsi_policy_ipv6
+      - test_iscsi_policy_updated
+
+  - name: Create iSCSI Static Target Policy - check-mode
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy
+      description: "Test iSCSI static target policy description"
+      target_name: "iqn.1991-05.com.microsoft:winclient1"
+      port: 3260
+      lun_id: 0
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.100"
+      tags:
+        - Key: Environment
+          Value: Test
+        - Key: Owner
+          Value: Automation
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify iSCSI policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response == {}
+
+  - name: Create iSCSI Static Target Policy
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy
+      description: "Test iSCSI static target policy description"
+      target_name: "iqn.1991-05.com.microsoft:winclient1"
+      port: 3260
+      lun_id: 0
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.100"
+      tags:
+        - Key: Environment
+          Value: Test
+        - Key: Owner
+          Value: Automation
+    register: creation_res
+
+  - name: Fetch info after creation
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy
+    register: creation_info_res
+
+  - name: Verify iSCSI policy creation by info
+    ansible.builtin.assert:
+      that:
+        - creation_res.changed
+        - creation_info_res.api_response.Name == 'test_iscsi_policy'
+        - creation_info_res.api_response.TargetName == 'iqn.1991-05.com.microsoft:winclient1'
+        - creation_info_res.api_response.Port == 3260
+        - creation_info_res.api_response.Lun.LunId == 0
+        - creation_info_res.api_response.IscsiIpType == 'IPv4'
+        - creation_info_res.api_response.IpAddress == '192.168.10.100'
+
+  - name: Create iSCSI Static Target Policy (idempotency check)
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy
+      description: "Test iSCSI static target policy description"
+      target_name: "iqn.1991-05.com.microsoft:winclient1"
+      port: 3260
+      lun_id: 0
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.100"
+      tags:
+        - Key: Environment
+          Value: Test
+        - Key: Owner
+          Value: Automation
+    register: creation_res_ide
+
+  - name: Fetch info after idempotency check
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy
+    register: idempotency_info_res
+
+  - name: Verify iSCSI policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not creation_res_ide.changed
+        - idempotency_info_res.api_response.Name == 'test_iscsi_policy'
+        - idempotency_info_res.api_response.Description == 'Test iSCSI static target policy description'
+
+  - name: Update description and LUN ID of an existing iSCSI policy
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy
+      description: "Updated iSCSI static target policy description"
+      target_name: "iqn.1991-05.com.microsoft:winclient1"
+      port: 3260
+      lun_id: 2
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.100"
+      tags:
+        - Key: Environment
+          Value: Test
+        - Key: Owner
+          Value: Automation
+    register: changed_res
+
+  - name: Fetch info after change
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy
+    register: change_info_res
+
+  - name: Verify iSCSI policy change by info
+    ansible.builtin.assert:
+      that:
+        - changed_res.changed
+        - change_info_res.api_response.Name == 'test_iscsi_policy'
+        - change_info_res.api_response.Description == 'Updated iSCSI static target policy description'
+        - change_info_res.api_response.Lun.LunId == 2
+
+  - name: Create another iSCSI Static Target Policy
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy_2
+      description: "Test another iSCSI static target policy"
+      target_name: "iqn.2001-04.com.example:storage.disk2"
+      port: 3260
+      lun_id: 1
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.101"
+    register: creation_res_b
+
+  - name: Fetch all iSCSI policies under selected organization
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+    register: creation_info_res_b
+
+  - name: Check that there are at least 2 iSCSI policies under this organization
+    ansible.builtin.assert:
+      that:
+        - creation_info_res_b.api_response | length > 1
+
+  - name: Test creation without optional parameters
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy_minimal
+      target_name: "iqn.1991-05.com.microsoft:winclient2"
+      port: 3260
+      lun_id: 0
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.102"
+    register: creation_res_minimal
+
+  - name: Fetch info after minimal creation
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy_minimal
+    register: minimal_info_res
+
+  - name: Verify minimal iSCSI policy creation
+    ansible.builtin.assert:
+      that:
+        - creation_res_minimal.changed
+        - minimal_info_res.api_response.Name == 'test_iscsi_policy_minimal'
+        - minimal_info_res.api_response.TargetName == 'iqn.1991-05.com.microsoft:winclient2'
+        - minimal_info_res.api_response.Port == 3260
+
+  - name: Create iSCSI Static Target Policy with IPv6
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy_ipv6
+      description: "iSCSI policy with IPv6 addressing"
+      target_name: "iqn.2001-04.com.example:storage.ipv6disk"
+      port: 3260
+      lun_id: 5
+      ip_protocol: "IPv6"
+      ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+      tags:
+        - Key: IPType
+          Value: IPv6
+    register: ipv6_creation_res
+
+  - name: Fetch info after IPv6 policy creation
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy_ipv6
+    register: ipv6_info_res
+
+  - name: Verify IPv6 iSCSI policy creation
+    ansible.builtin.assert:
+      that:
+        - ipv6_creation_res.changed
+        - ipv6_info_res.api_response.Name == 'test_iscsi_policy_ipv6'
+        - ipv6_info_res.api_response.IscsiIpType == 'IPv6'
+        - ipv6_info_res.api_response.IpAddress == '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+        - ipv6_info_res.api_response.Lun.LunId == 5
+
+  - name: Test info module - fetch specific policy
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy
+    register: specific_policy_info
+
+  - name: Verify specific policy info
+    ansible.builtin.assert:
+      that:
+        - specific_policy_info.api_response.Name == 'test_iscsi_policy'
+        - specific_policy_info.api_response.TargetName is defined
+
+  - name: Test info module - fetch all policies
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+    register: all_policies_info
+
+  - name: Verify all policies info
+    ansible.builtin.assert:
+      that:
+        - all_policies_info.api_response | length >= 4
+
+  - name: Update iSCSI policy - change IP address and port
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy_2
+      description: "Updated iSCSI policy with new IP and port"
+      target_name: "iqn.2001-04.com.example:storage.disk2"
+      port: 8080
+      lun_id: 1
+      ip_protocol: "IPv4"
+      ipv4_address: "192.168.10.200"
+    register: update_result
+
+  - name: Fetch info after update
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy_2
+    register: update_info_res
+
+  - name: Verify iSCSI policy update
+    ansible.builtin.assert:
+      that:
+        - update_result.changed
+        - update_info_res.api_response.Port == 8080
+        - update_info_res.api_response.IpAddress == '192.168.10.200'
+
+  - name: Test deletion of iSCSI policy
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: test_iscsi_policy_minimal
+      state: absent
+    register: deletion_result
+
+  - name: Verify deletion result
+    ansible.builtin.assert:
+      that:
+        - deletion_result.changed
+
+  - name: Verify policy is deleted by fetching info
+    cisco.intersight.intersight_iscsi_static_target_policy_info:
+      <<: *api_info
+      name: test_iscsi_policy_minimal
+    register: deleted_policy_info
+
+  - name: Verify policy no longer exists
+    ansible.builtin.assert:
+      that:
+        - deleted_policy_info.api_response == {}
+
+  always:
+  - name: Remove iSCSI Static Target policies
+    cisco.intersight.intersight_iscsi_static_target_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_iscsi_policy
+      - test_iscsi_policy_2
+      - test_iscsi_policy_minimal
+      - test_iscsi_policy_ipv6
+      - test_iscsi_policy_updated


### PR DESCRIPTION
#### SUMMARY
- Create  iscasi static target policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ iscasi_static_target _policy.py
- plugins/modules/intersight_iscasi_static_target _policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests