### PR TITLE
Fix a case in which 2 resources with the same name present in 2 different orgs

### DIFF
--- a/plugins/modules/intersight_lan_connectivity_policy.py
+++ b/plugins/modules/intersight_lan_connectivity_policy.py
@@ -874,7 +874,8 @@ def resolve_vnic_policy_moids(intersight, policy_cache, module, vnic_config, tar
     Resolve all policy MOIDs for a vNIC configuration based on target platform.
     """
     policy_mappings = get_vnic_policy_mappings(target_platform, vnic_config)
-    return resolve_policy_moids_from_mappings(intersight, policy_cache, module, vnic_config, policy_mappings)
+    organization_name = module.params['organization']
+    return resolve_policy_moids_from_mappings(intersight, policy_cache, module, vnic_config, policy_mappings, organization_name)
 
 
 def build_vnic_api_body(intersight, policy_cache, module, vnic_config, lan_connectivity_policy_moid):
@@ -913,7 +914,8 @@ def build_standalone_vnic_api_body(intersight, policy_cache, module, vnic_config
     vnic_api_body.update(policy_moids)
 
     # Add common connection type settings
-    connection_settings = build_connection_settings(intersight, policy_cache, module, vnic_config)
+    organization_name = module.params['organization']
+    connection_settings = build_connection_settings(intersight, policy_cache, module, vnic_config, organization_name)
     vnic_api_body.update(connection_settings)
 
     return vnic_api_body
@@ -976,7 +978,8 @@ def build_fi_attached_vnic_api_body(intersight, policy_cache, module, vnic_confi
     vnic_api_body.update(policy_moids)
 
     # Add common connection type settings
-    connection_settings = build_connection_settings(intersight, policy_cache, module, vnic_config)
+    organization_name = module.params['organization']
+    connection_settings = build_connection_settings(intersight, policy_cache, module, vnic_config, organization_name)
     vnic_api_body.update(connection_settings)
 
     return vnic_api_body
@@ -1110,12 +1113,14 @@ def main():
 
             # Resolve IQN pool MOID if specified
             if intersight.module.params['iqn_pool_name']:
-                iqn_pool_moid = intersight.get_moid_by_name(
+                iqn_pool_moid = intersight.get_moid_by_name_and_org(
                     resource_path='/iqnpool/Pools',
-                    resource_name=intersight.module.params['iqn_pool_name']
+                    resource_name=intersight.module.params['iqn_pool_name'],
+                    organization_name=intersight.module.params['organization']
                 )
                 if not iqn_pool_moid:
-                    intersight.module.fail_json(msg=f"IQN Pool '{intersight.module.params['iqn_pool_name']}' not found")
+                    intersight.module.fail_json(msg=f"IQN Pool '{intersight.module.params['iqn_pool_name']}' not found in organization ' \
+                    {intersight.module.params['organization']}'")
                 intersight.api_body['IqnPool'] = iqn_pool_moid
 
             if intersight.module.params['static_iqn_name']:

--- a/plugins/modules/intersight_port_policy.py
+++ b/plugins/modules/intersight_port_policy.py
@@ -1845,7 +1845,7 @@ def validate_input(module):
 
 def resolve_policy_moid(intersight, policy_cache, resource_path, policy_name, policy_type):
     """
-    Resolve policy name to MOID with caching.
+    Resolve policy name to MOID with caching and organization scoping.
 
     Args:
         intersight: IntersightModule instance
@@ -1862,13 +1862,15 @@ def resolve_policy_moid(intersight, policy_cache, resource_path, policy_name, po
     if cache_key in policy_cache:
         return policy_cache[cache_key]
 
-    moid = intersight.get_moid_by_name(
+    organization_name = intersight.module.params['organization']
+    moid = intersight.get_moid_by_name_and_org(
         resource_path=resource_path,
-        resource_name=policy_name
+        resource_name=policy_name,
+        organization_name=organization_name
     )
 
     if not moid:
-        intersight.module.fail_json(msg=f"{policy_type} '{policy_name}' not found")
+        intersight.module.fail_json(msg=f"{policy_type} '{policy_name}' not found in organization '{organization_name}'")
 
     policy_cache[cache_key] = moid
     return moid

--- a/plugins/modules/intersight_vlan_policy.py
+++ b/plugins/modules/intersight_vlan_policy.py
@@ -488,9 +488,18 @@ def main():
                         multicast_policy_moid = multicast_policy_cache[multicast_policy_name]
                     else:
                         # Fetch multicast policy MOID and cache it
-                        multicast_policy_moid = intersight.get_moid_by_name(resource_path='/fabric/MulticastPolicies', resource_name=multicast_policy_name)
+                        multicast_policy_moid = intersight.get_moid_by_name_and_org(
+                            resource_path='/fabric/MulticastPolicies',
+                            resource_name=multicast_policy_name,
+                            organization_name=intersight.module.params['organization']
+                        )
+                        if not multicast_policy_moid:
+                            module.fail_json(
+                                msg=f"Multicast policy '{multicast_policy_name}' not found in organization '{intersight.module.params['organization']}'"
+                            )
                         multicast_policy_cache[multicast_policy_name] = multicast_policy_moid
                     vlan_attach_api_body['MulticastPolicy'] = multicast_policy_moid
+
                 # Create the VLAN
                 resource_path = '/fabric/Vlans'
                 intersight.api_body = vlan_attach_api_body

--- a/plugins/modules/intersight_vnic_template.py
+++ b/plugins/modules/intersight_vnic_template.py
@@ -422,7 +422,8 @@ def resolve_policy_moids(intersight, policy_cache, module):
     Resolve all policy MOIDs for vNIC Template configuration.
     """
     policy_mappings = get_template_policy_mappings(module)
-    return resolve_policy_moids_from_mappings(intersight, policy_cache, module, module.params, policy_mappings)
+    organization_name = module.params['organization']
+    return resolve_policy_moids_from_mappings(intersight, policy_cache, module, module.params, policy_mappings, organization_name)
 
 
 def validate_input(module):
@@ -516,7 +517,8 @@ def main():
         intersight.api_body.update(policy_moids)
 
         # Add connection type specific settings
-        connection_settings = build_connection_settings(intersight, policy_cache, intersight.module, intersight.module.params)
+        organization_name = intersight.module.params['organization']
+        connection_settings = build_connection_settings(intersight, policy_cache, intersight.module, intersight.module.params, organization_name)
         intersight.api_body.update(connection_settings)
 
     intersight.configure_policy_or_profile(resource_path=resource_path)


### PR DESCRIPTION
Fixes #216 

When fetching the MOID of the resource we would not filter by using the org and it could result in getting resources from wrong organization.