### PR TITLE
Introduce iscsi adapter policy

### DIFF
--- a/plugins/modules/intersight_iscsi_adapter_policy.py
+++ b/plugins/modules/intersight_iscsi_adapter_policy.py
@@ -1,0 +1,238 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_iscsi_adapter_policy
+short_description: Manage iSCSI Adapter Policies for Cisco Intersight
+description:
+  - Create, update, and delete iSCSI Adapter Policies on Cisco Intersight.
+  - iSCSI adapter policies configure timeout and retry settings for iSCSI adapters.
+  - These policies control TCP connection timeout, DHCP timeout, and LUN busy retry behavior.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/vnic/IscsiAdapterPolicies/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the iSCSI Adapter Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the iSCSI Adapter Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  connection_time_out:
+    description:
+      - The number of seconds to wait until Cisco UCS assumes that the initial login has failed and the iSCSI adapter is unavailable.
+      - TCP connection timeout value.
+      - Valid range is 0 to 255 seconds.
+    type: int
+    default: 15
+  dhcp_timeout:
+    description:
+      - The number of seconds to wait before the initiator assumes that the DHCP server is unavailable.
+      - Valid range is 60 to 300 seconds.
+    type: int
+    default: 60
+  lun_busy_retry_count:
+    description:
+      - The number of times to retry the connection in case of a failure during iSCSI LUN discovery.
+      - Valid range is 0 to 60 retries.
+    type: int
+    default: 15
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create iSCSI Adapter Policy with default settings
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-adapter-default"
+    description: "iSCSI adapter policy with default timeout values"
+    state: present
+
+- name: Create iSCSI Adapter Policy with custom timeout settings
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-adapter-custom"
+    description: "iSCSI adapter policy with custom timeouts"
+    connection_time_out: 30
+    dhcp_timeout: 120
+    lun_busy_retry_count: 30
+    tags:
+      - Key: Environment
+        Value: Production
+    state: present
+
+- name: Create iSCSI Adapter Policy with extended timeouts
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+    name: "iscsi-adapter-extended"
+    description: "iSCSI adapter policy with extended timeout values"
+    connection_time_out: 60
+    dhcp_timeout: 300
+    lun_busy_retry_count: 60
+    state: present
+
+- name: Create iSCSI Adapter Policy with minimal timeouts
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-adapter-minimal"
+    description: "iSCSI adapter policy with minimal timeout values"
+    connection_time_out: 0
+    dhcp_timeout: 60
+    lun_busy_retry_count: 0
+    state: present
+
+- name: Update iSCSI Adapter Policy description
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-adapter-default"
+    description: "Updated iSCSI adapter policy description"
+    state: present
+
+- name: Delete iSCSI Adapter Policy
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "iscsi-adapter-default"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "iscsi-adapter-custom",
+        "ObjectType": "vnic.IscsiAdapterPolicy",
+        "ConnectionTimeOut": 30,
+        "DhcpTimeout": 120,
+        "LunBusyRetryCount": 30,
+        "Moid": "1234567890abcdef12345678",
+        "Description": "iSCSI adapter policy with custom timeouts",
+        "Organization": {
+            "Moid": "abcdef1234567890abcdef12",
+            "ObjectType": "organization.Organization"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def validate_parameters(module):
+    """
+    Validate module parameters for iSCSI adapter policy configuration.
+    """
+    if module.params['state'] != 'present':
+        return
+    # Validate connection_time_out range (0-255)
+    connection_time_out = module.params.get('connection_time_out')
+    if connection_time_out is not None and (connection_time_out < 0 or connection_time_out > 255):
+        module.fail_json(msg="Parameter 'connection_time_out' must be between 0 and 255 seconds")
+    # Validate dhcp_timeout range (60-300)
+    dhcp_timeout = module.params.get('dhcp_timeout')
+    if dhcp_timeout is not None and (dhcp_timeout < 60 or dhcp_timeout > 300):
+        module.fail_json(msg="Parameter 'dhcp_timeout' must be between 60 and 300 seconds")
+    # Validate lun_busy_retry_count range (0-60)
+    lun_busy_retry_count = module.params.get('lun_busy_retry_count')
+    if lun_busy_retry_count is not None and (lun_busy_retry_count < 0 or lun_busy_retry_count > 60):
+        module.fail_json(msg="Parameter 'lun_busy_retry_count' must be between 0 and 60 retries")
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        connection_time_out=dict(type='int', default=15),
+        dhcp_timeout=dict(type='int', default=60),
+        lun_busy_retry_count=dict(type='int', default=15),
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    # Validate module parameters
+    validate_parameters(module)
+    # Resource path used to configure policy
+    resource_path = '/vnic/IscsiAdapterPolicies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': module.params['organization'],
+        },
+        'Name': module.params['name'],
+    }
+    if module.params['state'] == 'present':
+        intersight.api_body['ConnectionTimeOut'] = module.params['connection_time_out']
+        intersight.api_body['DhcpTimeout'] = module.params['dhcp_timeout']
+        intersight.api_body['LunBusyRetryCount'] = module.params['lun_busy_retry_count']
+        intersight.set_tags_and_description()
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_iscsi_adapter_policy_info.py
+++ b/plugins/modules/intersight_iscsi_adapter_policy_info.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_iscsi_adapter_policy_info
+short_description: Gather information about iSCSI Adapter Policies in Cisco Intersight
+description:
+  - Retrieve information about iSCSI Adapter Policies from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization or policy name.
+  - Returns structured data with policy metadata and iSCSI adapter configuration details.
+  - If no filters are provided, all iSCSI Adapter Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter iSCSI Adapter Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the iSCSI Adapter Policy to retrieve information from.
+      - When specified, only the matching policy will be returned.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all iSCSI Adapter Policies from all organizations
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_iscsi_adapter_policies
+
+# Organization-specific Examples
+- name: Fetch all iSCSI Adapter Policies from the default organization
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all iSCSI Adapter Policies from a custom organization
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific iSCSI Adapter Policy by name
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "iscsi-adapter-policy-01"
+  register: specific_policy
+
+- name: Fetch a specific policy from a specific organization
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Production"
+    name: "iscsi-adapter-policy-prod"
+  register: specific_org_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing iSCSI Adapter Policy information.
+    - Returns a list.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "iscsi-adapter-policy-01",
+        "ObjectType": "vnic.IscsiAdapterPolicy",
+        "Moid": "1234567890abcdef12345678",
+        "Description": "iSCSI adapter policy for production servers",
+        "ConnectionTimeOut": 30,
+        "DhcpTimeout": 120,
+        "LunBusyRetryCount": 30,
+        "Organization": {
+          "Name": "default",
+          "ObjectType": "organization.Organization",
+          "Moid": "abcdef1234567890abcdef12"
+        },
+        "Tags": [
+          {
+            "Key": "Environment",
+            "Value": "Production"
+          },
+          {
+            "Key": "Owner",
+            "Value": "Storage-Team"
+          }
+        ]
+      }
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    # Resource path used to fetch policy info
+    resource_path = '/vnic/IscsiAdapterPolicies'
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+    # Get iSCSI Adapter policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_iscsi_adapter_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_iscsi_adapter_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_iscsi_adapter_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_iscsi_adapter_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_run

--- a/tests/integration/targets/intersight_iscsi_adapter_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_iscsi_adapter_policy/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Run iSCSI Adapter Policy tests
+  ansible.builtin.include_tasks: tests.yml

--- a/tests/integration/targets/intersight_iscsi_adapter_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_iscsi_adapter_policy/tasks/tests.yml
@@ -1,0 +1,350 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      organization: "{{ organization }}"
+
+- name: Make sure Environment is clean
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_iscsi_adapter_policy_minimal
+    - test_iscsi_adapter_policy_default
+    - test_iscsi_adapter_policy_custom
+    - test_iscsi_adapter_policy_extended
+    - test_iscsi_adapter_policy_edge_min
+    - test_iscsi_adapter_policy_edge_max
+    - test_iscsi_adapter_policy_check_mode
+
+- name: Create iSCSI Adapter Policy with minimal parameters
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_minimal
+  register: result
+
+- name: Verify creation result
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_minimal'
+      - result.api_response.Moid is defined
+      - result.api_response.ObjectType == 'vnic.IscsiAdapterPolicy'
+      - result.api_response.ConnectionTimeOut == 15
+      - result.api_response.DhcpTimeout == 60
+      - result.api_response.LunBusyRetryCount == 15
+
+- name: Create same iSCSI Adapter Policy again (idempotency)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_minimal
+  register: result
+
+- name: Verify idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_minimal'
+
+- name: Create iSCSI Adapter Policy with default values
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_default
+    description: "Test iSCSI adapter policy with default values"
+    connection_time_out: 15
+    dhcp_timeout: 60
+    lun_busy_retry_count: 15
+  register: result
+
+- name: Verify default values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_default'
+      - result.api_response.Description == 'Test iSCSI adapter policy with default values'
+      - result.api_response.ConnectionTimeOut == 15
+      - result.api_response.DhcpTimeout == 60
+      - result.api_response.LunBusyRetryCount == 15
+
+- name: Create iSCSI Adapter Policy with custom timeouts
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_custom
+    description: "Test iSCSI adapter policy with custom timeouts"
+    connection_time_out: 30
+    dhcp_timeout: 120
+    lun_busy_retry_count: 30
+    tags:
+      - Key: Environment
+        Value: Test
+      - Key: Owner
+        Value: Automation
+  register: result
+
+- name: Verify custom values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_custom'
+      - result.api_response.ConnectionTimeOut == 30
+      - result.api_response.DhcpTimeout == 120
+      - result.api_response.LunBusyRetryCount == 30
+      - result.api_response.Tags | length == 2
+
+- name: Update iSCSI Adapter Policy description
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_custom
+    description: "Updated description for test policy"
+    connection_time_out: 30
+    dhcp_timeout: 120
+    lun_busy_retry_count: 30
+  register: result
+
+- name: Verify update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Description == 'Updated description for test policy'
+      - result.api_response.ConnectionTimeOut == 30
+
+- name: Update iSCSI Adapter Policy timeout values
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_custom
+    description: "Updated description for test policy"
+    connection_time_out: 45
+    dhcp_timeout: 180
+    lun_busy_retry_count: 40
+  register: result
+
+- name: Verify timeout update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.ConnectionTimeOut == 45
+      - result.api_response.DhcpTimeout == 180
+      - result.api_response.LunBusyRetryCount == 40
+
+- name: Create iSCSI Adapter Policy with extended timeouts
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_extended
+    description: "Test policy with maximum timeout values"
+    connection_time_out: 60
+    dhcp_timeout: 300
+    lun_busy_retry_count: 60
+  register: result
+
+- name: Verify extended timeout policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_extended'
+      - result.api_response.ConnectionTimeOut == 60
+      - result.api_response.DhcpTimeout == 300
+      - result.api_response.LunBusyRetryCount == 60
+
+- name: Create iSCSI Adapter Policy with minimum edge values
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_edge_min
+    description: "Test policy with minimum timeout values"
+    connection_time_out: 0
+    dhcp_timeout: 60
+    lun_busy_retry_count: 0
+  register: result
+
+- name: Verify minimum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_edge_min'
+      - result.api_response.ConnectionTimeOut == 0
+      - result.api_response.DhcpTimeout == 60
+      - result.api_response.LunBusyRetryCount == 0
+
+- name: Create iSCSI Adapter Policy with maximum edge values
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_edge_max
+    description: "Test policy with maximum timeout values"
+    connection_time_out: 255
+    dhcp_timeout: 300
+    lun_busy_retry_count: 60
+  register: result
+
+- name: Verify maximum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_iscsi_adapter_policy_edge_max'
+      - result.api_response.ConnectionTimeOut == 255
+      - result.api_response.DhcpTimeout == 300
+      - result.api_response.LunBusyRetryCount == 60
+
+- name: Test invalid connection_time_out value (too high)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    connection_time_out: 256
+  register: test_invalid_connection_timeout_result
+  failed_when:
+    - test_invalid_connection_timeout_result.failed == false
+    - "'connection_time_out' not in test_invalid_connection_timeout_result.msg"
+
+- name: Test invalid connection_time_out value (too low)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    connection_time_out: -1
+  register: test_invalid_connection_timeout_low_result
+  failed_when:
+    - test_invalid_connection_timeout_low_result.failed == false
+    - "'connection_time_out' not in test_invalid_connection_timeout_low_result.msg"
+
+- name: Test invalid dhcp_timeout value (too high)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    dhcp_timeout: 301
+  register: test_invalid_dhcp_timeout_result
+  failed_when:
+    - test_invalid_dhcp_timeout_result.failed == false
+    - "'dhcp_timeout' not in test_invalid_dhcp_timeout_result.msg"
+
+- name: Test invalid dhcp_timeout value (too low)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    dhcp_timeout: 59
+  register: test_invalid_dhcp_timeout_low_result
+  failed_when:
+    - test_invalid_dhcp_timeout_low_result.failed == false
+    - "'dhcp_timeout' not in test_invalid_dhcp_timeout_low_result.msg"
+
+- name: Test invalid lun_busy_retry_count value (too high)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    lun_busy_retry_count: 61
+  register: test_invalid_lun_retry_result
+  failed_when:
+    - test_invalid_lun_retry_result.failed == false
+    - "'lun_busy_retry_count' not in test_invalid_lun_retry_result.msg"
+
+- name: Test invalid lun_busy_retry_count value (too low)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_invalid
+    lun_busy_retry_count: -1
+  register: test_invalid_lun_retry_low_result
+  failed_when:
+    - test_invalid_lun_retry_low_result.failed == false
+    - "'lun_busy_retry_count' not in test_invalid_lun_retry_low_result.msg"
+
+- name: Test check mode - create
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_check_mode
+    description: "Check mode test policy"
+    connection_time_out: 25
+  check_mode: true
+  register: result
+
+- name: Verify check mode behavior
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response == {}
+
+- name: Get iSCSI Adapter Policy info to verify check mode
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_check_mode
+  register: result
+
+- name: Verify policy was not created
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 0
+
+- name: Get all iSCSI Adapter Policies
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    <<: *api_info
+  register: result
+
+- name: Verify info module returns data
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Get specific iSCSI Adapter Policy by name
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_custom
+  register: result
+
+- name: Verify specific policy retrieval
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 1
+      - result.api_response[0].Name == 'test_iscsi_adapter_policy_custom'
+      - result.api_response[0].ConnectionTimeOut == 45
+      - result.api_response[0].DhcpTimeout == 180
+      - result.api_response[0].LunBusyRetryCount == 40
+
+- name: Get iSCSI Adapter Policies by organization
+  cisco.intersight.intersight_iscsi_adapter_policy_info:
+    <<: *api_info
+    organization: "{{ organization }}"
+  register: result
+
+- name: Verify organization filtering
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Delete iSCSI Adapter Policy
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion
+  ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Delete same iSCSI Adapter Policy again (idempotency)
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: test_iscsi_adapter_policy_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+
+# Cleanup - Delete all test policies
+- name: Cleanup all test policies
+  cisco.intersight.intersight_iscsi_adapter_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_iscsi_adapter_policy_default
+    - test_iscsi_adapter_policy_custom
+    - test_iscsi_adapter_policy_extended
+    - test_iscsi_adapter_policy_edge_min
+    - test_iscsi_adapter_policy_edge_max


### PR DESCRIPTION
#### SUMMARY
- Create  iscsi  adapter policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ iscsi_adapter _policy.py
- plugins/modules/intersight_iscasi_adapter _policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests