### PR TITLE
Introduce fibre channel qos module

### DIFF
--- a/plugins/modules/intersight_fibre_channel_qos_policy.py
+++ b/plugins/modules/intersight_fibre_channel_qos_policy.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_qos_policy
+short_description: Manage Fibre Channel QoS Policies for Cisco Intersight
+description:
+  - Create, update, and delete Fibre Channel QoS Policies on Cisco Intersight.
+  - Fibre Channel QoS policies configure Quality of Service settings for Fibre Channel virtual interfaces.
+  - These policies control bandwidth rate limits, maximum data field size, class of service, and burst traffic.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/vnic/FcQosPolicies/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Fibre Channel QoS Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Fibre Channel QoS Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  rate_limit:
+    description:
+      - The value in Mbps to use for limiting the data rate on the virtual interface.
+      - A value of 0 means no rate limiting.
+      - Valid range is 0 to 100000 Mbps.
+    type: int
+    default: 0
+  max_data_field_size:
+    description:
+      - The maximum size of the Fibre Channel frame payload bytes that the virtual interface supports.
+      - Valid range is 256 to 2112 bytes.
+    type: int
+    default: 2112
+  cos:
+    description:
+      - Class of Service to be associated to the traffic on the virtual interface.
+      - Valid range is 0 to 6.
+    type: int
+    default: 3
+  burst:
+    description:
+      - The burst traffic, in bytes, allowed on the vHBA.
+      - Valid range is 1 to 1000000 bytes.
+    type: int
+    default: 10240
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create Fibre Channel QoS Policy with default settings
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-qos-default"
+    description: "Fibre Channel QoS policy with default values"
+    state: present
+
+- name: Create Fibre Channel QoS Policy with custom settings
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-qos-custom"
+    description: "Fibre Channel QoS policy with custom values"
+    rate_limit: 10000
+    max_data_field_size: 2048
+    cos: 5
+    burst: 20480
+    tags:
+      - Key: Environment
+        Value: Production
+    state: present
+
+- name: Create Fibre Channel QoS Policy with maximum rate limit
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+    name: "fc-qos-high-bandwidth"
+    description: "Fibre Channel QoS policy with maximum bandwidth"
+    rate_limit: 100000
+    max_data_field_size: 2112
+    cos: 6
+    burst: 1000000
+    state: present
+
+- name: Create Fibre Channel QoS Policy with minimal frame size
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-qos-minimal"
+    description: "Fibre Channel QoS policy with minimal frame size"
+    rate_limit: 0
+    max_data_field_size: 256
+    cos: 0
+    burst: 1
+    state: present
+
+- name: Update Fibre Channel QoS Policy description
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-qos-default"
+    description: "Updated Fibre Channel QoS policy description"
+    state: present
+
+- name: Delete Fibre Channel QoS Policy
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-qos-default"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "fc-qos-custom",
+        "ObjectType": "vnic.FcQosPolicy",
+        "RateLimit": 10000,
+        "MaxDataFieldSize": 2048,
+        "Cos": 5,
+        "Burst": 20480,
+        "Moid": "1234567890abcdef12345678",
+        "Description": "Fibre Channel QoS policy with custom values",
+        "Organization": {
+            "Moid": "abcdef1234567890abcdef12",
+            "ObjectType": "organization.Organization"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def validate_parameters(module):
+    """
+    Validate module parameters for Fibre Channel QoS policy configuration.
+    """
+    if module.params['state'] != 'present':
+        return
+    # Validate rate_limit range (0-100000)
+    rate_limit = module.params.get('rate_limit')
+    if rate_limit is not None and (rate_limit < 0 or rate_limit > 100000):
+        module.fail_json(msg="Parameter 'rate_limit' must be between 0 and 100000 Mbps")
+    # Validate max_data_field_size range (256-2112)
+    max_data_field_size = module.params.get('max_data_field_size')
+    if max_data_field_size is not None and (max_data_field_size < 256 or max_data_field_size > 2112):
+        module.fail_json(msg="Parameter 'max_data_field_size' must be between 256 and 2112 bytes")
+    # Validate cos range (0-6)
+    cos = module.params.get('cos')
+    if cos is not None and (cos < 0 or cos > 6):
+        module.fail_json(msg="Parameter 'cos' must be between 0 and 6")
+    # Validate burst range (1-1000000)
+    burst = module.params.get('burst')
+    if burst is not None and (burst < 1 or burst > 1000000):
+        module.fail_json(msg="Parameter 'burst' must be between 1 and 1000000 bytes")
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        rate_limit=dict(type='int', default=0),
+        max_data_field_size=dict(type='int', default=2112),
+        cos=dict(type='int', default=3),
+        burst=dict(type='int', default=10240),
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    # Validate module parameters
+    validate_parameters(module)
+    # Resource path used to configure policy
+    resource_path = '/vnic/FcQosPolicies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': module.params['organization'],
+        },
+        'Name': module.params['name'],
+    }
+    if module.params['state'] == 'present':
+        intersight.api_body['RateLimit'] = module.params['rate_limit']
+        intersight.api_body['MaxDataFieldSize'] = module.params['max_data_field_size']
+        intersight.api_body['Cos'] = module.params['cos']
+        intersight.api_body['Burst'] = module.params['burst']
+        intersight.set_tags_and_description()
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_fibre_channel_qos_policy_info.py
+++ b/plugins/modules/intersight_fibre_channel_qos_policy_info.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_qos_policy_info
+short_description: Gather information about Fibre Channel QoS Policies in Cisco Intersight
+description:
+  - Retrieve information about Fibre Channel QoS Policies from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization or policy name.
+  - Returns structured data with policy metadata and Fibre Channel QoS configuration details.
+  - If no filters are provided, all Fibre Channel QoS Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter Fibre Channel QoS Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the Fibre Channel QoS Policy to retrieve information from.
+      - When specified, only the matching policy will be returned.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all Fibre Channel QoS Policies from all organizations
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_fc_qos_policies
+
+# Organization-specific Examples
+- name: Fetch all Fibre Channel QoS Policies from the default organization
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all Fibre Channel QoS Policies from a custom organization
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific Fibre Channel QoS Policy by name
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "fc-qos-policy-01"
+  register: specific_policy
+
+- name: Fetch a specific policy from a specific organization
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Production"
+    name: "fc-qos-policy-prod"
+  register: specific_org_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing Fibre Channel QoS Policy information.
+    - Returns a list.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "fc-qos-policy-01",
+        "ObjectType": "vnic.FcQosPolicy",
+        "Moid": "1234567890abcdef12345678",
+        "Description": "Fibre Channel QoS policy for production servers",
+        "RateLimit": 10000,
+        "MaxDataFieldSize": 2048,
+        "Cos": 5,
+        "Burst": 20480,
+        "Organization": {
+          "Name": "default",
+          "ObjectType": "organization.Organization",
+          "Moid": "abcdef1234567890abcdef12"
+        },
+        "Tags": [
+          {
+            "Key": "Environment",
+            "Value": "Production"
+          },
+          {
+            "Key": "Owner",
+            "Value": "Storage-Team"
+          }
+        ]
+      }
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    # Resource path used to fetch policy info
+    resource_path = '/vnic/FcQosPolicies'
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+    # Get Fibre Channel QoS policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_fibre_channel_qos_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_qos_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet" 

--- a/tests/integration/targets/intersight_fibre_channel_qos_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_qos_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_run

--- a/tests/integration/targets/intersight_fibre_channel_qos_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_qos_policy/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Run Fibre Channel QoS Policy tests
+  ansible.builtin.import_tasks: tests.yml

--- a/tests/integration/targets/intersight_fibre_channel_qos_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_fibre_channel_qos_policy/tasks/tests.yml
@@ -1,0 +1,385 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      organization: "{{ organization }}"
+
+- name: Make sure Environment is clean
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_fc_qos_policy_minimal
+    - test_fc_qos_policy_default
+    - test_fc_qos_policy_custom
+    - test_fc_qos_policy_high_bandwidth
+    - test_fc_qos_policy_edge_min
+    - test_fc_qos_policy_edge_max
+    - test_fc_qos_policy_check_mode
+
+- name: Create Fibre Channel QoS Policy with minimal parameters
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_minimal
+  register: result
+
+- name: Verify creation result
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_minimal'
+      - result.api_response.Moid is defined
+      - result.api_response.ObjectType == 'vnic.FcQosPolicy'
+      - result.api_response.RateLimit == 0
+      - result.api_response.MaxDataFieldSize == 2112
+      - result.api_response.Cos == 3
+      - result.api_response.Burst == 10240
+
+- name: Create same Fibre Channel QoS Policy again (idempotency)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_minimal
+  register: result
+
+- name: Verify idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.api_response.Name == 'test_fc_qos_policy_minimal'
+
+- name: Create Fibre Channel QoS Policy with default values
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_default
+    description: "Test Fibre Channel QoS policy with default values"
+    rate_limit: 0
+    max_data_field_size: 2112
+    cos: 3
+    burst: 10240
+  register: result
+
+- name: Verify default values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_default'
+      - result.api_response.Description == 'Test Fibre Channel QoS policy with default values'
+      - result.api_response.RateLimit == 0
+      - result.api_response.MaxDataFieldSize == 2112
+      - result.api_response.Cos == 3
+      - result.api_response.Burst == 10240
+
+- name: Create Fibre Channel QoS Policy with custom values
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_custom
+    description: "Test Fibre Channel QoS policy with custom values"
+    rate_limit: 10000
+    max_data_field_size: 2048
+    cos: 5
+    burst: 20480
+    tags:
+      - Key: Environment
+        Value: Test
+      - Key: Owner
+        Value: Automation
+  register: result
+
+- name: Verify custom values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_custom'
+      - result.api_response.RateLimit == 10000
+      - result.api_response.MaxDataFieldSize == 2048
+      - result.api_response.Cos == 5
+      - result.api_response.Burst == 20480
+      - result.api_response.Tags | length == 2
+
+- name: Update Fibre Channel QoS Policy description
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_custom
+    description: "Updated description for test policy"
+    rate_limit: 10000
+    max_data_field_size: 2048
+    cos: 5
+    burst: 20480
+  register: result
+
+- name: Verify update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Description == 'Updated description for test policy'
+      - result.api_response.RateLimit == 10000
+
+- name: Update Fibre Channel QoS Policy values
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_custom
+    description: "Updated description for test policy"
+    rate_limit: 15000
+    max_data_field_size: 1024
+    cos: 4
+    burst: 30000
+  register: result
+
+- name: Verify value update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.RateLimit == 15000
+      - result.api_response.MaxDataFieldSize == 1024
+      - result.api_response.Cos == 4
+      - result.api_response.Burst == 30000
+
+- name: Create Fibre Channel QoS Policy with high bandwidth settings
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_high_bandwidth
+    description: "Test policy with high bandwidth values"
+    rate_limit: 50000
+    max_data_field_size: 2112
+    cos: 6
+    burst: 500000
+  register: result
+
+- name: Verify high bandwidth policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_high_bandwidth'
+      - result.api_response.RateLimit == 50000
+      - result.api_response.MaxDataFieldSize == 2112
+      - result.api_response.Cos == 6
+      - result.api_response.Burst == 500000
+
+- name: Create Fibre Channel QoS Policy with minimum edge values
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_edge_min
+    description: "Test policy with minimum values"
+    rate_limit: 0
+    max_data_field_size: 256
+    cos: 0
+    burst: 1
+  register: result
+
+- name: Verify minimum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_edge_min'
+      - result.api_response.RateLimit == 0
+      - result.api_response.MaxDataFieldSize == 256
+      - result.api_response.Cos == 0
+      - result.api_response.Burst == 1
+
+- name: Create Fibre Channel QoS Policy with maximum edge values
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_edge_max
+    description: "Test policy with maximum values"
+    rate_limit: 100000
+    max_data_field_size: 2112
+    cos: 6
+    burst: 1000000
+  register: result
+
+- name: Verify maximum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_qos_policy_edge_max'
+      - result.api_response.RateLimit == 100000
+      - result.api_response.MaxDataFieldSize == 2112
+      - result.api_response.Cos == 6
+      - result.api_response.Burst == 1000000
+
+- name: Test invalid rate_limit value (too high)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    rate_limit: 100001
+  register: test_invalid_rate_limit_result
+  failed_when:
+    - test_invalid_rate_limit_result.failed == false
+    - "'rate_limit' not in test_invalid_rate_limit_result.msg"
+
+- name: Test invalid rate_limit value (too low)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    rate_limit: -1
+  register: test_invalid_rate_limit_low_result
+  failed_when:
+    - test_invalid_rate_limit_low_result.failed == false
+    - "'rate_limit' not in test_invalid_rate_limit_low_result.msg"
+
+- name: Test invalid max_data_field_size value (too high)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    max_data_field_size: 2113
+  register: test_invalid_max_data_field_size_result
+  failed_when:
+    - test_invalid_max_data_field_size_result.failed == false
+    - "'max_data_field_size' not in test_invalid_max_data_field_size_result.msg"
+
+- name: Test invalid max_data_field_size value (too low)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    max_data_field_size: 255
+  register: test_invalid_max_data_field_size_low_result
+  failed_when:
+    - test_invalid_max_data_field_size_low_result.failed == false
+    - "'max_data_field_size' not in test_invalid_max_data_field_size_low_result.msg"
+
+- name: Test invalid cos value (too high)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    cos: 7
+  register: test_invalid_cos_result
+  failed_when:
+    - test_invalid_cos_result.failed == false
+    - "'cos' not in test_invalid_cos_result.msg"
+
+- name: Test invalid cos value (too low)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    cos: -1
+  register: test_invalid_cos_low_result
+  failed_when:
+    - test_invalid_cos_low_result.failed == false
+    - "'cos' not in test_invalid_cos_low_result.msg"
+
+- name: Test invalid burst value (too high)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    burst: 1000001
+  register: test_invalid_burst_result
+  failed_when:
+    - test_invalid_burst_result.failed == false
+    - "'burst' not in test_invalid_burst_result.msg"
+
+- name: Test invalid burst value (too low)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_invalid
+    burst: 0
+  register: test_invalid_burst_low_result
+  failed_when:
+    - test_invalid_burst_low_result.failed == false
+    - "'burst' not in test_invalid_burst_low_result.msg"
+
+- name: Test check mode - create
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_check_mode
+    description: "Check mode test policy"
+    rate_limit: 5000
+  check_mode: true
+  register: result
+
+- name: Verify check mode behavior
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response == {}
+
+- name: Get Fibre Channel QoS Policy info to verify check mode
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    <<: *api_info
+    name: test_fc_qos_policy_check_mode
+  register: result
+
+- name: Verify policy was not created
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 0
+
+- name: Get all Fibre Channel QoS Policies
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    <<: *api_info
+  register: result
+
+- name: Verify info module returns data
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Get specific Fibre Channel QoS Policy by name
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    <<: *api_info
+    name: test_fc_qos_policy_custom
+  register: result
+
+- name: Verify specific policy retrieval
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 1
+      - result.api_response[0].Name == 'test_fc_qos_policy_custom'
+      - result.api_response[0].RateLimit == 15000
+      - result.api_response[0].MaxDataFieldSize == 1024
+      - result.api_response[0].Cos == 4
+      - result.api_response[0].Burst == 30000
+
+- name: Get Fibre Channel QoS Policies by organization
+  cisco.intersight.intersight_fibre_channel_qos_policy_info:
+    <<: *api_info
+    organization: "{{ organization }}"
+  register: result
+
+- name: Verify organization filtering
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Delete Fibre Channel QoS Policy
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion
+  ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Delete same Fibre Channel QoS Policy again (idempotency)
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: test_fc_qos_policy_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+
+# Cleanup - Delete all test policies
+- name: Cleanup all test policies
+  cisco.intersight.intersight_fibre_channel_qos_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_fc_qos_policy_default
+    - test_fc_qos_policy_custom
+    - test_fc_qos_policy_high_bandwidth
+    - test_fc_qos_policy_edge_min
+    - test_fc_qos_policy_edge_max


### PR DESCRIPTION
#### SUMMARY
- Create  fibre channel policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ fibre_channel_policy.py
- plugins/modules/intersight_fibre_channel_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests