### PR TITLE
Introduce fibre channel network policy

### DIFF
--- a/plugins/modules/intersight_fibre_channel_network_policy.py
+++ b/plugins/modules/intersight_fibre_channel_network_policy.py
@@ -1,0 +1,226 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_network_policy
+short_description: Manage Fibre Channel Network Policies for Cisco Intersight
+description:
+  - Create, update, and delete Fibre Channel Network Policies on Cisco Intersight.
+  - Fibre Channel Network policies configure VSAN settings for Fibre Channel virtual interfaces.
+  - These policies control the default VLAN ID and VSAN ID assignments for FC networks.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/vnic/FcNetworkPolicies/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Fibre Channel Network Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Fibre Channel Network Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  default_vlan:
+    description:
+      - The default VLAN ID for the Fibre Channel network.
+      - Valid range is 0 to 4094.
+      - A value of 0 means the VLAN is not configured.
+    type: int
+    default: 0
+  vsan_id:
+    description:
+      - The VSAN (Virtual Storage Area Network) ID for the Fibre Channel network.
+      - Valid range is 1 to 4094.
+    type: int
+    default: 1
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create Fibre Channel Network Policy with default settings
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-network-default"
+    description: "Fibre Channel Network policy with default values"
+    state: present
+
+- name: Create Fibre Channel Network Policy with custom VSAN settings
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-network-vsan100"
+    description: "Fibre Channel Network policy for VSAN 100"
+    default_vlan: 100
+    vsan_id: 100
+    tags:
+      - Key: Environment
+        Value: Production
+    state: present
+
+- name: Create Fibre Channel Network Policy with VLAN and different VSAN
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+    name: "fc-network-custom"
+    description: "Custom Fibre Channel Network policy"
+    default_vlan: 200
+    vsan_id: 300
+    state: present
+
+- name: Create Fibre Channel Network Policy with maximum VSAN ID
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-network-max-vsan"
+    description: "Fibre Channel Network policy with maximum VSAN ID"
+    default_vlan: 4094
+    vsan_id: 4094
+    state: present
+
+- name: Update Fibre Channel Network Policy description
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-network-default"
+    description: "Updated Fibre Channel Network policy description"
+    state: present
+
+- name: Delete Fibre Channel Network Policy
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-network-default"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "fc-network-vsan100",
+        "ObjectType": "vnic.FcNetworkPolicy",
+        "Moid": "1234567890abcdef12345678",
+        "Description": "Fibre Channel Network policy for VSAN 100",
+        "VsanSettings": {
+            "DefaultVlanId": 100,
+            "Id": 100
+        },
+        "Organization": {
+            "Moid": "abcdef1234567890abcdef12",
+            "ObjectType": "organization.Organization"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def validate_parameters(module):
+    """
+    Validate module parameters for Fibre Channel Network policy configuration.
+    """
+    if module.params['state'] != 'present':
+        return
+    # Validate default_vlan range (0-4094)
+    default_vlan = module.params.get('default_vlan')
+    if default_vlan is not None and (default_vlan < 0 or default_vlan > 4094):
+        module.fail_json(msg="Parameter 'default_vlan' must be between 0 and 4094")
+    # Validate vsan_id range (1-4094)
+    vsan_id = module.params.get('vsan_id')
+    if vsan_id is not None and (vsan_id < 1 or vsan_id > 4094):
+        module.fail_json(msg="Parameter 'vsan_id' must be between 1 and 4094")
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        default_vlan=dict(type='int', default=0),
+        vsan_id=dict(type='int', default=1),
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+    # Validate module parameters
+    validate_parameters(module)
+    # Resource path used to configure policy
+    resource_path = '/vnic/FcNetworkPolicies'
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': module.params['organization'],
+        },
+        'Name': module.params['name'],
+    }
+    if module.params['state'] == 'present':
+        intersight.api_body['VsanSettings'] = {
+            'DefaultVlanId': module.params['default_vlan'],
+            'Id': module.params['vsan_id'],
+        }
+        intersight.set_tags_and_description()
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_fibre_channel_network_policy_info.py
+++ b/plugins/modules/intersight_fibre_channel_network_policy_info.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_network_policy_info
+short_description: Gather information about Fibre Channel Network Policies in Cisco Intersight
+description:
+  - Retrieve information about Fibre Channel Network Policies from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization or policy name.
+  - Returns structured data with policy metadata and Fibre Channel Network configuration details.
+  - If no filters are provided, all Fibre Channel Network Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter Fibre Channel Network Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the Fibre Channel Network Policy to retrieve information from.
+      - When specified, only the matching policy will be returned.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all Fibre Channel Network Policies from all organizations
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_fc_network_policies
+
+# Organization-specific Examples
+- name: Fetch all Fibre Channel Network Policies from the default organization
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all Fibre Channel Network Policies from a custom organization
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific Fibre Channel Network Policy by name
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "fc-network-policy-01"
+  register: specific_policy
+
+- name: Fetch a specific policy from a specific organization
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Production"
+    name: "fc-network-policy-prod"
+  register: specific_org_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing Fibre Channel Network Policy information.
+    - Returns a list.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "fc-network-policy-01",
+        "ObjectType": "vnic.FcNetworkPolicy",
+        "Moid": "1234567890abcdef12345678",
+        "Description": "Fibre Channel Network policy for production servers",
+        "VsanSettings": {
+          "DefaultVlanId": 100,
+          "Id": 100
+        },
+        "Organization": {
+          "Name": "default",
+          "ObjectType": "organization.Organization",
+          "Moid": "abcdef1234567890abcdef12"
+        },
+        "Tags": [
+          {
+            "Key": "Environment",
+            "Value": "Production"
+          },
+          {
+            "Key": "Owner",
+            "Value": "Storage-Team"
+          }
+        ]
+      }
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Resource path used to fetch policy info
+    resource_path = '/vnic/FcNetworkPolicies'
+
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+
+    # Get Fibre Channel Network policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_fibre_channel_network_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_network_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_fibre_channel_network_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_network_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_run

--- a/tests/integration/targets/intersight_fibre_channel_network_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_network_policy/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Run Fibre Channel Network Policy tests
+  ansible.builtin.import_tasks: tests.yml

--- a/tests/integration/targets/intersight_fibre_channel_network_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_fibre_channel_network_policy/tasks/tests.yml
@@ -1,0 +1,316 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ api_private_key }}"
+      api_key_id: "{{ api_key_id }}"
+      api_uri: "{{ api_uri | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(omit) }}"
+      organization: "{{ organization }}"
+
+- name: Make sure Environment is clean
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_fc_network_minimal
+    - test_fc_network_default
+    - test_fc_network_custom
+    - test_fc_network_high_vsan
+    - test_fc_network_edge_min
+    - test_fc_network_edge_max
+    - test_fc_network_check_mode
+
+- name: Create Fibre Channel Network Policy with minimal parameters
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_minimal
+  register: result
+
+- name: Verify creation result
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_minimal'
+      - result.api_response.Moid is defined
+      - result.api_response.ObjectType == 'vnic.FcNetworkPolicy'
+      - result.api_response.VsanSettings.DefaultVlanId == 0
+      - result.api_response.VsanSettings.Id == 1
+
+- name: Create same Fibre Channel Network Policy again (idempotency)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_minimal
+  register: result
+
+- name: Verify idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.api_response.Name == 'test_fc_network_minimal'
+
+- name: Create Fibre Channel Network Policy with default values
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_default
+    description: "Test Fibre Channel Network policy with default values"
+    default_vlan: 0
+    vsan_id: 1
+  register: result
+
+- name: Verify default values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_default'
+      - result.api_response.Description == 'Test Fibre Channel Network policy with default values'
+      - result.api_response.VsanSettings.DefaultVlanId == 0
+      - result.api_response.VsanSettings.Id == 1
+
+- name: Create Fibre Channel Network Policy with custom values
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_custom
+    description: "Test Fibre Channel Network policy with custom values"
+    default_vlan: 100
+    vsan_id: 100
+    tags:
+      - Key: Environment
+        Value: Test
+      - Key: Owner
+        Value: Automation
+  register: result
+
+- name: Verify custom values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_custom'
+      - result.api_response.VsanSettings.DefaultVlanId == 100
+      - result.api_response.VsanSettings.Id == 100
+      - result.api_response.Tags | length == 2
+
+- name: Update Fibre Channel Network Policy description
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_custom
+    description: "Updated description for test policy"
+    default_vlan: 100
+    vsan_id: 100
+  register: result
+
+- name: Verify update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Description == 'Updated description for test policy'
+      - result.api_response.VsanSettings.DefaultVlanId == 100
+
+- name: Update Fibre Channel Network Policy values
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_custom
+    description: "Updated description for test policy"
+    default_vlan: 200
+    vsan_id: 300
+  register: result
+
+- name: Verify value update
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.VsanSettings.DefaultVlanId == 200
+      - result.api_response.VsanSettings.Id == 300
+
+- name: Create Fibre Channel Network Policy with high VSAN settings
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_high_vsan
+    description: "Test policy with high VSAN values"
+    default_vlan: 2000
+    vsan_id: 2500
+  register: result
+
+- name: Verify high VSAN policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_high_vsan'
+      - result.api_response.VsanSettings.DefaultVlanId == 2000
+      - result.api_response.VsanSettings.Id == 2500
+
+- name: Create Fibre Channel Network Policy with minimum edge values
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_edge_min
+    description: "Test policy with minimum values"
+    default_vlan: 0
+    vsan_id: 1
+  register: result
+
+- name: Verify minimum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_edge_min'
+      - result.api_response.VsanSettings.DefaultVlanId == 0
+      - result.api_response.VsanSettings.Id == 1
+
+- name: Create Fibre Channel Network Policy with maximum edge values
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_edge_max
+    description: "Test policy with maximum values"
+    default_vlan: 4094
+    vsan_id: 4094
+  register: result
+
+- name: Verify maximum edge values policy
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response.Name == 'test_fc_network_edge_max'
+      - result.api_response.VsanSettings.DefaultVlanId == 4094
+      - result.api_response.VsanSettings.Id == 4094
+
+- name: Test invalid default_vlan value (too high)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_invalid
+    default_vlan: 4095
+  register: test_invalid_default_vlan_result
+  failed_when:
+    - test_invalid_default_vlan_result.failed == false
+    - "'default_vlan' not in test_invalid_default_vlan_result.msg"
+
+- name: Test invalid default_vlan value (too low)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_invalid
+    default_vlan: -1
+  register: test_invalid_default_vlan_low_result
+  failed_when:
+    - test_invalid_default_vlan_low_result.failed == false
+    - "'default_vlan' not in test_invalid_default_vlan_low_result.msg"
+
+- name: Test invalid vsan_id value (too high)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_invalid
+    vsan_id: 4095
+  register: test_invalid_vsan_id_result
+  failed_when:
+    - test_invalid_vsan_id_result.failed == false
+    - "'vsan_id' not in test_invalid_vsan_id_result.msg"
+
+- name: Test invalid vsan_id value (too low)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_invalid
+    vsan_id: 0
+  register: test_invalid_vsan_id_low_result
+  failed_when:
+    - test_invalid_vsan_id_low_result.failed == false
+    - "'vsan_id' not in test_invalid_vsan_id_low_result.msg"
+
+- name: Test check mode - create
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_check_mode
+    description: "Check mode test policy"
+    default_vlan: 500
+    vsan_id: 600
+  check_mode: true
+  register: result
+
+- name: Verify check mode behavior
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.api_response == {}
+
+- name: Get Fibre Channel Network Policy info to verify check mode
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    <<: *api_info
+    name: test_fc_network_check_mode
+  register: result
+
+- name: Verify policy was not created
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 0
+
+- name: Get all Fibre Channel Network Policies
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    <<: *api_info
+  register: result
+
+- name: Verify info module returns data
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Get specific Fibre Channel Network Policy by name
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    <<: *api_info
+    name: test_fc_network_custom
+  register: result
+
+- name: Verify specific policy retrieval
+  ansible.builtin.assert:
+    that:
+      - result.api_response | length == 1
+      - result.api_response[0].Name == 'test_fc_network_custom'
+      - result.api_response[0].VsanSettings.DefaultVlanId == 200
+      - result.api_response[0].VsanSettings.Id == 300
+
+- name: Get Fibre Channel Network Policies by organization
+  cisco.intersight.intersight_fibre_channel_network_policy_info:
+    <<: *api_info
+    organization: "{{ organization }}"
+  register: result
+
+- name: Verify organization filtering
+  ansible.builtin.assert:
+    that:
+      - result.api_response is defined
+      - result.api_response | length >= 1
+
+- name: Delete Fibre Channel Network Policy
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion
+  ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Delete same Fibre Channel Network Policy again (idempotency)
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: test_fc_network_minimal
+    state: absent
+  register: result
+
+- name: Verify deletion idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+
+# Cleanup - Delete all test policies
+- name: Cleanup all test policies
+  cisco.intersight.intersight_fibre_channel_network_policy:
+    <<: *api_info
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_fc_network_default
+    - test_fc_network_custom
+    - test_fc_network_high_vsan
+    - test_fc_network_edge_min
+    - test_fc_network_edge_max


### PR DESCRIPTION
#### SUMMARY
- Create  fibre channel network policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ fibre_channel_network_policy.py
- plugins/modules/intersight_fibre_channel_network_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests