### PR TITLE
Introduce fibre channel zone policy

### DIFF
--- a/plugins/modules/intersight_fibre_channel_zone_policy.py
+++ b/plugins/modules/intersight_fibre_channel_zone_policy.py
@@ -1,0 +1,365 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_zone_policy
+short_description: Manage Fibre Channel Zone Policies for Cisco Intersight
+description:
+  - Create, update, and delete Fibre Channel Zone Policies on Cisco Intersight.
+  - Manage FC target members (zones) within FC zone policies.
+  - FC Zone policies define zoning configurations for Fibre Channel networks.
+  - Supports SIST (Single Initiator Single Target), SIMT (Single Initiator Multiple Target), and None zoning types.
+  - When zoning type is None, targets cannot be added and existing targets will be disabled.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs/fabric/FcZonePolicies/get/).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Policies created within a Custom Organization are applicable only to devices in the same Organization.
+      - Use 'default' for the default organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Fibre Channel Zone Policy.
+      - Must be unique within the organization.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the Fibre Channel Zone Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  fc_target_zoning_type:
+    description:
+      - Type of FC zoning configuration.
+      - C(SIST) - Single Initiator Single Target zoning.
+      - C(SIMT) - Single Initiator Multiple Target zoning.
+      - C(None) - No zoning. When None is selected, targets cannot be added and existing targets will be disabled.
+    type: str
+    choices: [SIST, SIMT, None]
+    default: None
+  fc_target_members:
+    description:
+      - List of FC target members (zones) to be created within the FC zone policy.
+      - Each target defines a WWPN that is a member of the FC zone.
+      - Leave empty when fc_target_zoning_type is None.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Name identifier for the FC target member.
+          - Must be unique within the policy.
+        type: str
+        required: true
+      wwpn:
+        description:
+          - World Wide Port Name (WWPN) that is a member of the FC zone.
+          - Format should be colon-separated hex values (e.g., 21:00:00:e0:8b:05:05:04).
+          - Must be a valid WWPN format.
+        type: str
+        required: true
+      switch_id:
+        description:
+          - Unique identifier for the Fabric object.
+          - Specifies which fabric interconnect the target is associated with.
+        type: str
+        choices: [A, B]
+        default: A
+      vsan_id:
+        description:
+          - VSAN ID with scope defined as Storage in the VSAN policy.
+          - Must be between 1 and 4093.
+        type: int
+        required: true
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create FC Zone Policy with SIMT zoning and multiple targets
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-simt"
+    description: "FC Zone policy with SIMT zoning"
+    fc_target_zoning_type: SIMT
+    fc_target_members:
+      - name: "target1"
+        wwpn: "21:00:00:e0:8b:05:05:04"
+        switch_id: A
+        vsan_id: 100
+      - name: "target2"
+        wwpn: "21:00:00:e0:8b:05:05:03"
+        switch_id: B
+        vsan_id: 100
+      - name: "target3"
+        wwpn: "21:00:00:e0:8b:05:05:09"
+        switch_id: A
+        vsan_id: 200
+    tags:
+      - Key: Environment
+        Value: Production
+    state: present
+
+- name: Create FC Zone Policy with SIST zoning
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-sist"
+    description: "FC Zone policy with SIST zoning"
+    fc_target_zoning_type: SIST
+    fc_target_members:
+      - name: "single-target"
+        wwpn: "21:00:00:e0:8b:05:05:01"
+        switch_id: A
+        vsan_id: 100
+    state: present
+
+- name: Create FC Zone Policy with no zoning (None type)
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-none"
+    description: "FC Zone policy with no zoning"
+    fc_target_zoning_type: None
+    state: present
+
+- name: Update FC Zone Policy - add new target
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-simt"
+    description: "Updated FC Zone policy"
+    fc_target_zoning_type: SIMT
+    fc_target_members:
+      - name: "target1"
+        wwpn: "21:00:00:e0:8b:05:05:04"
+        switch_id: A
+        vsan_id: 100
+      - name: "target2"
+        wwpn: "21:00:00:e0:8b:05:05:03"
+        switch_id: B
+        vsan_id: 100
+      - name: "target3"
+        wwpn: "21:00:00:e0:8b:05:05:09"
+        switch_id: A
+        vsan_id: 200
+      - name: "target4"
+        wwpn: "21:00:00:e0:8b:05:05:10"
+        switch_id: B
+        vsan_id: 200
+    state: present
+
+- name: Update FC Zone Policy - remove a target (only specify remaining targets)
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-simt"
+    fc_target_zoning_type: SIMT
+    fc_target_members:
+      - name: "target1"
+        wwpn: "21:00:00:e0:8b:05:05:04"
+        switch_id: A
+        vsan_id: 100
+      - name: "target3"
+        wwpn: "21:00:00:e0:8b:05:05:09"
+        switch_id: A
+        vsan_id: 200
+    state: present
+
+- name: Delete FC Zone Policy
+  cisco.intersight.intersight_fibre_channel_zone_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "fc-zone-policy-simt"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "fc-zone-policy-simt",
+        "ObjectType": "fabric.FcZonePolicy",
+        "Moid": "1234567890abcdef12345678",
+        "Description": "FC Zone policy with SIMT zoning",
+        "FcTargetZoningType": "SIMT",
+        "FcTargetMembers": [
+            {
+                "Name": "target1",
+                "Wwpn": "21:00:00:e0:8b:05:05:04",
+                "SwitchId": "A",
+                "VsanId": 100
+            },
+            {
+                "Name": "target2",
+                "Wwpn": "21:00:00:e0:8b:05:05:03",
+                "SwitchId": "B",
+                "VsanId": 100
+            }
+        ],
+        "Organization": {
+            "Moid": "abcdef1234567890abcdef12",
+            "ObjectType": "organization.Organization"
+        },
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+import re
+
+
+def validate_wwpn(wwpn):
+    """
+    Validate WWPN format.
+    """
+    wwpn_pattern = r'^([0-9a-fA-F]{2}:){7}[0-9a-fA-F]{2}$'
+    if not re.match(wwpn_pattern, wwpn):
+        raise ValueError(f"Invalid WWPN format '{wwpn}'. Expected format: XX:XX:XX:XX:XX:XX:XX:XX (hex values)")
+    return True
+
+
+def validate_vsan_id(vsan_id):
+    """
+    Validate VSAN ID is within acceptable range (1-4093).
+    """
+    if vsan_id < 1 or vsan_id > 4093:
+        raise ValueError(f"VSAN ID {vsan_id} is out of valid range (1-4093)")
+    return True
+
+
+def validate_parameters(module):
+    """
+    Validate module parameters for FC Zone policy configuration.
+    """
+    if module.params['state'] != 'present':
+        return
+    fc_target_zoning_type = module.params.get('fc_target_zoning_type')
+    fc_target_members = module.params.get('fc_target_members', [])
+    # Validate that if zoning type is None, no targets should be provided
+    if fc_target_zoning_type == 'None' and fc_target_members:
+        module.fail_json(msg="When fc_target_zoning_type is 'None', fc_target_members should be empty. Targets cannot be added when zoning type is None.")
+    # Validate fc_target_members if provided
+    if fc_target_members:
+        for target in fc_target_members:
+            # Validate WWPN format
+            wwpn = target.get('wwpn')
+            if wwpn:
+                try:
+                    validate_wwpn(wwpn)
+                except ValueError as e:
+                    module.fail_json(msg=str(e))
+            # Validate VSAN ID range
+            vsan_id = target.get('vsan_id')
+            if vsan_id:
+                try:
+                    validate_vsan_id(vsan_id)
+                except ValueError as e:
+                    module.fail_json(msg=str(e))
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        fc_target_zoning_type=dict(type='str', choices=['SIST', 'SIMT', 'None'], default='None'),
+        fc_target_members=dict(type='list', elements='dict', options=dict(
+            name=dict(type='str', required=True),
+            wwpn=dict(type='str', required=True),
+            switch_id=dict(type='str', choices=['A', 'B'], default='A'),
+            vsan_id=dict(type='int', required=True)
+        ))
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Validate module parameters
+    validate_parameters(module)
+
+    # Resource path used to configure policy
+    resource_path = '/fabric/FcZonePolicies'
+
+    # Define API body used in compares or create
+    intersight.api_body = {
+        'Organization': {
+            'Name': module.params['organization'],
+        },
+        'Name': module.params['name']
+    }
+
+    if module.params['state'] == 'present':
+        intersight.api_body['FcTargetZoningType'] = module.params['fc_target_zoning_type']
+        # Build FcTargetMembers list
+        fc_target_members = []
+        if module.params.get('fc_target_members'):
+            for target in module.params['fc_target_members']:
+                fc_target_members.append({
+                    'Name': target['name'],
+                    'Wwpn': target['wwpn'],
+                    'SwitchId': target['switch_id'],
+                    'VsanId': target['vsan_id']
+                })
+        intersight.api_body['FcTargetMembers'] = fc_target_members
+        intersight.set_tags_and_description()
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_fibre_channel_zone_policy_info.py
+++ b/plugins/modules/intersight_fibre_channel_zone_policy_info.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_fibre_channel_zone_policy_info
+short_description: Gather information about Fibre Channel Zone Policies in Cisco Intersight
+description:
+  - Retrieve comprehensive information about Fibre Channel Zone Policies from L(Cisco Intersight,https://intersight.com).
+  - Query policies by organization or policy name.
+  - FC target members are embedded in the policy object as FcTargetMembers array.
+  - If no filters are provided, all FC Zone Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization to filter FC Zone Policies by.
+      - Use 'default' for the default organization.
+      - When specified, only policies from this organization will be returned.
+    type: str
+  name:
+    description:
+      - The exact name of the FC Zone Policy to retrieve information from.
+      - When specified, only the matching policy will be returned.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+# Basic Usage Examples
+- name: Fetch all FC Zone Policies from all organizations
+  cisco.intersight.intersight_fibre_channel_zone_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+  register: all_fc_zone_policies
+
+- name: Display all policies
+  debug:
+    msg: "Found {{ all_fc_zone_policies.api_response | length }} FC Zone Policies"
+
+# Organization-specific Examples
+- name: Fetch all FC Zone Policies from the default organization
+  cisco.intersight.intersight_fibre_channel_zone_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+  register: default_org_policies
+
+- name: Fetch all FC Zone Policies from a custom organization
+  cisco.intersight.intersight_fibre_channel_zone_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "Engineering"
+  register: engineering_policies
+
+# Specific Policy Examples
+- name: Fetch a specific FC Zone Policy by name
+  cisco.intersight.intersight_fibre_channel_zone_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "fc-zone-policy-simt"
+  register: specific_policy
+'''
+
+RETURN = r'''
+api_response:
+  description:
+    - The API response containing policy information including embedded FC target members.
+    - Returns a dictionary when querying a single policy.
+    - Returns a list when multiple policies are found.
+  returned: always
+  type: dict
+  sample:
+    Name: "fc-zone-policy-simt"
+    ObjectType: "fabric.FcZonePolicy"
+    Moid: "12345678901234567890abcd"
+    Description: "FC Zone policy with SIMT zoning"
+    FcTargetZoningType: "SIMT"
+    FcTargetMembers:
+      - Name: "target1"
+        Wwpn: "21:00:00:e0:8b:05:05:04"
+        SwitchId: "A"
+        VsanId: 100
+      - Name: "target2"
+        Wwpn: "21:00:00:e0:8b:05:05:03"
+        SwitchId: "B"
+        VsanId: 100
+    Organization:
+      Name: "default"
+      ObjectType: "organization.Organization"
+    Tags:
+      - Key: "Environment"
+        Value: "Production"
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+
+    # Resource path used to fetch policy info
+    resource_path = '/fabric/FcZonePolicies'
+
+    # Get query parameters for policies
+    query_params = intersight.set_query_params()
+
+    # Get FC Zone policies
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_fibre_channel_zone_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_zone_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_fibre_channel_zone_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_zone_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_run

--- a/tests/integration/targets/intersight_fibre_channel_zone_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_fibre_channel_zone_policy/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- ansible.builtin.import_tasks: tests.yml

--- a/tests/integration/targets/intersight_fibre_channel_zone_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_fibre_channel_zone_policy/tasks/tests.yml
@@ -1,0 +1,380 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_fc_zone_policy
+      - test_fc_zone_policy_2
+      - test_fc_zone_policy_minimal
+      - test_fc_zone_policy_simt
+      - test_fc_zone_policy_sist
+      - test_fc_zone_policy_none
+      - test_fc_zone_policy_with_targets
+
+  - name: Create FC zone policy - check-mode
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy
+      description: "Test FC Zone policy description"
+      fc_target_zoning_type: None
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    check_mode: true
+    register: creation_res_check_mode
+
+  - name: Verify FC zone policy was not created - check-mode
+    ansible.builtin.assert:
+      that:
+        - creation_res_check_mode is changed
+        - creation_res_check_mode.api_response == {}
+
+  - name: Create FC zone policy
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy
+      description: "Test FC Zone policy description"
+      fc_target_zoning_type: None
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: creation_res
+
+  - name: Fetch info after creation
+    cisco.intersight.intersight_fibre_channel_zone_policy_info:
+      <<: *api_info
+      name: test_fc_zone_policy
+    register: creation_info_res
+
+  - name: Verify FC zone policy creation by info
+    ansible.builtin.assert:
+      that:
+        - creation_res.changed
+        - creation_info_res.api_response[0].Name == 'test_fc_zone_policy'
+
+  - name: Verify FC zone policy creation response aligns with info response
+    ansible.builtin.assert:
+      that:
+        - creation_res.api_response.Name == creation_info_res.api_response[0].Name
+
+  - name: Create FC zone policy (idempotency check)
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy
+      description: "Test FC Zone policy description"
+      fc_target_zoning_type: None
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: creation_res_ide
+
+  - name: Verify FC zone policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not creation_res_ide.changed
+
+  - name: Update description of an existing FC zone policy
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy
+      description: "Updated FC Zone policy description"
+      fc_target_zoning_type: None
+      tags:
+        - Key: Site
+          Value: Test
+        - Key: Site2
+          Value: Test2
+    register: changed_res
+
+  - name: Fetch info after change
+    cisco.intersight.intersight_fibre_channel_zone_policy_info:
+      <<: *api_info
+      name: test_fc_zone_policy
+    register: change_info_res
+
+  - name: Verify FC zone policy change by info
+    ansible.builtin.assert:
+      that:
+        - changed_res.changed
+        - change_info_res.api_response[0].Name == 'test_fc_zone_policy'
+        - change_info_res.api_response[0].Description == 'Updated FC Zone policy description'
+
+  - name: Create another FC zone policy
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_2
+      description: "Test another FC Zone policy description"
+      fc_target_zoning_type: None
+    register: creation_res_b
+
+  - name: Fetch all FC zone policies under selected organization
+    cisco.intersight.intersight_fibre_channel_zone_policy_info:
+      <<: *api_info
+    register: creation_info_res_b
+
+  - name: Check that there are at least 2 FC zone policies under this organization
+    ansible.builtin.assert:
+      that:
+        - creation_info_res_b.api_response | length > 1
+
+  - name: Test creation without optional parameters
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_minimal
+    register: creation_res_minimal
+
+  - name: Verify minimal FC zone policy creation
+    ansible.builtin.assert:
+      that:
+        - creation_res_minimal.changed
+        - creation_res_minimal.api_response.Name == 'test_fc_zone_policy_minimal'
+
+  - name: Create FC zone policy with SIMT zoning and multiple targets
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_simt
+      description: "Policy with SIMT zoning and multiple targets"
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "target1"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 100
+        - name: "target2"
+          wwpn: "21:00:00:e0:8b:05:05:03"
+          switch_id: B
+          vsan_id: 100
+        - name: "target3"
+          wwpn: "21:00:00:e0:8b:05:05:09"
+          switch_id: A
+          vsan_id: 200
+    register: fc_zone_policy_simt
+
+  - name: Verify FC zone policy with SIMT zoning and targets creation
+    ansible.builtin.assert:
+      that:
+        - fc_zone_policy_simt.changed
+        - fc_zone_policy_simt.api_response.Name == 'test_fc_zone_policy_simt'
+        - fc_zone_policy_simt.api_response.FcTargetZoningType == 'SIMT'
+        - fc_zone_policy_simt.api_response.FcTargetMembers | length == 3
+        - fc_zone_policy_simt.api_response.FcTargetMembers[0].Name == 'target1'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[1].Name == 'target2'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[2].Name == 'target3'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[0].Wwpn == '21:00:00:e0:8b:05:05:04'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[1].Wwpn == '21:00:00:e0:8b:05:05:03'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[2].Wwpn == '21:00:00:e0:8b:05:05:09'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[0].SwitchId == 'A'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[1].SwitchId == 'B'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[2].SwitchId == 'A'
+        - fc_zone_policy_simt.api_response.FcTargetMembers[0].VsanId == 100
+        - fc_zone_policy_simt.api_response.FcTargetMembers[1].VsanId == 100
+        - fc_zone_policy_simt.api_response.FcTargetMembers[2].VsanId == 200
+
+  - name: Create FC zone policy with SIMT again (idempotency check)
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_simt
+      description: "Policy with SIMT zoning and multiple targets"
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "target1"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 100
+        - name: "target2"
+          wwpn: "21:00:00:e0:8b:05:05:03"
+          switch_id: B
+          vsan_id: 100
+        - name: "target3"
+          wwpn: "21:00:00:e0:8b:05:05:09"
+          switch_id: A
+          vsan_id: 200
+    register: fc_zone_policy_simt_idempotent
+
+  - name: Verify FC zone policy with SIMT idempotency
+    ansible.builtin.assert:
+      that:
+        - not fc_zone_policy_simt_idempotent.changed
+
+  - name: Create FC zone policy with SIST zoning
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_sist
+      description: "Policy with SIST zoning"
+      fc_target_zoning_type: SIST
+      fc_target_members:
+        - name: "single-target"
+          wwpn: "21:00:00:e0:8b:05:05:01"
+          switch_id: A
+          vsan_id: 100
+    register: fc_zone_policy_sist
+
+  - name: Verify FC zone policy with SIST zoning creation
+    ansible.builtin.assert:
+      that:
+        - fc_zone_policy_sist.changed
+        - fc_zone_policy_sist.api_response.Name == 'test_fc_zone_policy_sist'
+        - fc_zone_policy_sist.api_response.FcTargetZoningType == 'SIST'
+        - fc_zone_policy_sist.api_response.FcTargetMembers | length == 1
+        - fc_zone_policy_sist.api_response.FcTargetMembers[0].Name == 'single-target'
+        - fc_zone_policy_sist.api_response.FcTargetMembers[0].Wwpn == '21:00:00:e0:8b:05:05:01'
+        - fc_zone_policy_sist.api_response.FcTargetMembers[0].SwitchId == 'A'
+        - fc_zone_policy_sist.api_response.FcTargetMembers[0].VsanId == 100
+
+  - name: Create FC zone policy with None zoning
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_none
+      description: "Policy with None zoning"
+      fc_target_zoning_type: None
+    register: fc_zone_policy_none
+
+  - name: Verify FC zone policy with None zoning creation
+    ansible.builtin.assert:
+      that:
+        - fc_zone_policy_none.changed
+        - fc_zone_policy_none.api_response.Name == 'test_fc_zone_policy_none'
+        - fc_zone_policy_none.api_response.FcTargetZoningType == 'None'
+        - fc_zone_policy_none.api_response.FcTargetMembers | length == 0
+
+  - name: Test info module - fetch specific policy with FC targets
+    cisco.intersight.intersight_fibre_channel_zone_policy_info:
+      <<: *api_info
+      name: test_fc_zone_policy_simt
+    register: specific_policy_info
+
+  - name: Verify specific policy info
+    ansible.builtin.assert:
+      that:
+        - specific_policy_info.api_response[0].Name == 'test_fc_zone_policy_simt'
+        - specific_policy_info.api_response[0].FcTargetMembers | length == 3
+
+  - name: Test info module - fetch all policies
+    cisco.intersight.intersight_fibre_channel_zone_policy_info:
+      <<: *api_info
+    register: all_policies_info
+
+  - name: Verify all policies info
+    ansible.builtin.assert:
+      that:
+        - all_policies_info.api_response | length >= 4
+
+  - name: Update FC zone policy - remove one FC target
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_simt
+      description: "Policy with reduced FC targets"
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "target1"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 100
+        - name: "target3"
+          wwpn: "21:00:00:e0:8b:05:05:09"
+          switch_id: A
+          vsan_id: 200
+    register: fc_target_removal_result
+
+  - name: Verify FC target removal
+    ansible.builtin.assert:
+      that:
+        - fc_target_removal_result.changed
+        - fc_target_removal_result.api_response.Name == 'test_fc_zone_policy_simt'
+        - fc_target_removal_result.api_response.FcTargetMembers | length == 2
+        - fc_target_removal_result.api_response.FcTargetMembers[0].Name == 'target1'
+        - fc_target_removal_result.api_response.FcTargetMembers[1].Name == 'target3'
+
+  # Test validation errors
+  - name: Test invalid WWPN format
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_with_targets
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "invalid-target"
+          wwpn: "invalid_wwpn_format"
+          switch_id: A
+          vsan_id: 100
+    register: test_invalid_wwpn_result
+    failed_when:
+      - test_invalid_wwpn_result.failed == false
+      - "'Invalid WWPN format' not in test_invalid_wwpn_result.msg"
+
+  - name: Test invalid VSAN ID (too low)
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_with_targets
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "invalid-vsan-target"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 0
+    register: test_invalid_vsan_low_result
+    failed_when:
+      - test_invalid_vsan_low_result.failed == false
+      - "'out of valid range' not in test_invalid_vsan_low_result.msg"
+
+  - name: Test invalid VSAN ID (too high)
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_with_targets
+      fc_target_zoning_type: SIMT
+      fc_target_members:
+        - name: "invalid-vsan-target"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 5000
+    register: test_invalid_vsan_high_result
+    failed_when:
+      - test_invalid_vsan_high_result.failed == false
+      - "'out of valid range' not in test_invalid_vsan_high_result.msg"
+
+  - name: Test targets with None zoning type (should fail)
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: test_fc_zone_policy_with_targets
+      fc_target_zoning_type: None
+      fc_target_members:
+        - name: "should-fail"
+          wwpn: "21:00:00:e0:8b:05:05:04"
+          switch_id: A
+          vsan_id: 100
+    register: test_targets_with_none_result
+    failed_when:
+      - test_targets_with_none_result.failed == false
+      - "'fc_target_members should be empty' not in test_targets_with_none_result.msg"
+
+  always:
+  - name: Remove FC zone policies
+    cisco.intersight.intersight_fibre_channel_zone_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_fc_zone_policy
+      - test_fc_zone_policy_2
+      - test_fc_zone_policy_minimal
+      - test_fc_zone_policy_simt
+      - test_fc_zone_policy_sist
+      - test_fc_zone_policy_none
+      - test_fc_zone_policy_with_targets


### PR DESCRIPTION
#### SUMMARY
- Create  fibre channel zone policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ fibre_channel_zone_policy.py
- plugins/modules/intersight_fibre_channel_zone_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests