### PR TITLE
https://github.com/CiscoDevNet/intersight-ansible/issues/243

### DIFF
--- a/plugins/modules/intersight_san_connectivity_policy.py
+++ b/plugins/modules/intersight_san_connectivity_policy.py
@@ -754,10 +754,11 @@ def main():
                 intersight.api_body = vhba_api_body
 
             resource_path = '/vnic/FcIfs'
+            custom_filter = f"Name eq '{vhba_config['name']}' and SanConnectivityPolicy.Moid eq '{san_connectivity_policy_moid}'"
             intersight.configure_secondary_resource(
                 resource_path=resource_path,
-                resource_name=vhba_config['name'],
-                state=vhba_state
+                state=vhba_state,
+                custom_filter=custom_filter
             )
             if vhba_state == 'present':
                 vhbas_response.append(intersight.result['api_response'])


### PR DESCRIPTION
### Fix for issue243
[issue243](https://github.com/CiscoDevNet/intersight-ansible/issues/243)
In the intersight_san_connectivity_policy.py module (lines 756-761), 
when creating or updating vHBAs, it calls configure_secondary_resource with only the vHBA name as a filter:

#### The problem: 
This filter searches across ALL SAN Connectivity Policies in the organization! 
If multiple policies have vHBAs with the same name (e.g., "vhba0", "vhba-a"), 
the query can return the wrong vHBA from a different policy, causing it to be accidentally modified or deleted.

#### The Fix
Add the SAN Connectivity Policy MOID to the filter to ensure we only find vHBAs that belong to the current policy