### PR TITLE
https://github.com/CiscoDevNet/intersight-ansible/issues/246

### DIFF
--- a/plugins/modules/intersight_lan_connectivity_policy.py
+++ b/plugins/modules/intersight_lan_connectivity_policy.py
@@ -1154,10 +1154,12 @@ def main():
 
             # Configure the vNIC (create/update/delete)
             resource_path = '/vnic/EthIfs'
+            # Filter by both vNIC name AND LAN Connectivity Policy to avoid affecting vNICs in other policies
+            custom_filter = f"Name eq '{vnic_config['name']}' and LanConnectivityPolicy.Moid eq '{lan_connectivity_policy_moid}'"
             intersight.configure_secondary_resource(
                 resource_path=resource_path,
-                resource_name=vnic_config['name'],
-                state=vnic_state
+                state=vnic_state,
+                custom_filter=custom_filter
             )
 
             # Save the vNIC response only if it's present


### PR DESCRIPTION
#### Fix for issue 246
[issue 246](https://github.com/CiscoDevNet/intersight-ansible/issues/246)

In the intersight_lan_connectivity_policy.py module (lines 1155-1162),
when creating or updating vNICs, it calls configure_secondary_resource with only the vNIC name as a filter:

#### The problem:
This filter searches across ALL LAN Connectivity Policies in the organization!
If multiple policies have vNICs with the same name (e.g., "eth0", "eth1"),
the query can return the wrong vNIC from a different policy, causing it to be accidentally modified or deleted.

#### The Fix:
Add the LAN Connectivity Policy MOID to the filter to ensure we only find vNICs that belong to the current policy