### PR TITLE
Fix for objects with name being removed

### DIFF
--- a/plugins/modules/intersight_port_policy.py
+++ b/plugins/modules/intersight_port_policy.py
@@ -2800,10 +2800,12 @@ def configure_pin_groups(intersight, port_policy_moid, pin_groups, uplink_pc_moi
             resource_path = '/fabric/SanPinGroups'
 
         # Configure the pin group
+        # Filter by both pin group name AND PortPolicy to avoid affecting pin groups in other policies
+        custom_filter = f"Name eq '{resource_name}' and PortPolicy.Moid eq '{port_policy_moid}'"
         intersight.configure_secondary_resource(
             resource_path=resource_path,
-            resource_name=resource_name,
-            state=pin_group_state
+            state=pin_group_state,
+            custom_filter=custom_filter
         )
 
 

--- a/plugins/modules/intersight_storage_policy.py
+++ b/plugins/modules/intersight_storage_policy.py
@@ -771,9 +771,13 @@ def main():
             # Create the drive group
             resource_path = '/storage/DriveGroups'
             intersight.api_body = drive_group_api_body
-            intersight.configure_secondary_resource(resource_path=resource_path,
-                                                    resource_name=drive_group_config['name'],
-                                                    state=drive_group_config.get('state', 'present'))
+            # Filter by both DriveGroup name AND StoragePolicy to avoid affecting DriveGroups in other policies
+            custom_filter = f"Name eq '{drive_group_config['name']}' and StoragePolicy.Moid eq '{storage_policy_moid}'"
+            intersight.configure_secondary_resource(
+                resource_path=resource_path,
+                state=drive_group_config.get('state', 'present'),
+                custom_filter=custom_filter
+            )
 
             # Save the drive group response
             drive_groups_response.append(intersight.result['api_response'])

--- a/plugins/modules/intersight_vlan_policy.py
+++ b/plugins/modules/intersight_vlan_policy.py
@@ -503,7 +503,13 @@ def main():
                 # Create the VLAN
                 resource_path = '/fabric/Vlans'
                 intersight.api_body = vlan_attach_api_body
-                intersight.configure_secondary_resource(resource_path=resource_path, resource_name=vlan_name, state=vlan_state)
+                # Filter by both VLAN name AND EthNetworkPolicy to avoid affecting VLANs in other policies
+                custom_filter = f"Name eq '{vlan_name}' and EthNetworkPolicy.Moid eq '{vlan_policy_moid}'"
+                intersight.configure_secondary_resource(
+                    resource_path=resource_path,
+                    state=vlan_state,
+                    custom_filter=custom_filter
+                )
                 # Store the VLAN response
                 final_response['vlans'].append(intersight.result['api_response'])
                 # Save the changed state and reset for next operation

--- a/plugins/modules/intersight_vsan_policy.py
+++ b/plugins/modules/intersight_vsan_policy.py
@@ -320,7 +320,13 @@ def main():
 
             # Create or delete the VSAN
             resource_path = '/fabric/Vsans'
-            intersight.configure_secondary_resource(resource_path=resource_path, resource_name=vsan_name, state=vsan_state)
+            # Filter by both VSAN name AND FcNetworkPolicy to avoid affecting VSANs in other policies
+            custom_filter = f"Name eq '{vsan_name}' and FcNetworkPolicy.Moid eq '{vsan_policy_moid}'"
+            intersight.configure_secondary_resource(
+                resource_path=resource_path,
+                state=vsan_state,
+                custom_filter=custom_filter
+            )
 
             # Store the VSAN response
             if intersight.result.get('api_response'):

--- a/tests/integration/targets/intersight_port_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_port_policy/tasks/tests.yml
@@ -249,6 +249,14 @@
           ports:
             - port_id: "36"
             - port_id: "37"
+          eth_network_group_policy_names:
+            - "test-eth-network-group-for-port-policy"
+          state: present
+        - pc_id: 2
+          admin_speed: "25Gbps"
+          fec: "Auto"
+          user_label: "Ethernet Uplink PC 2 - Breakout"
+          ports:
             - port_id: "49/1"
             - port_id: "49/2"
           eth_network_group_policy_names:


### PR DESCRIPTION
#### Fix for issue 248
[issue 248](https://github.com/CiscoDevNet/intersight-ansible/issues/248)
Some modules use configure_secondary_resource  and use on;y the object name as a filter:

#### The problem:
This filter searches across ALL Policies in the organization!
If multiple policies have the same name,
the query can return the wrong object from a different policy, causing it to be accidentally modified or deleted.

#### The Fix:
Add the MOID to the filter to ensure we only find objects that belong to the current policy