### PR TITLE
Add to galaxy build ignore list

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -62,3 +62,8 @@ build_ignore:
   - releases
   - debug
   - playbooks
+  - docs
+  - .github
+  - .ansible-lint
+  - .vscode
+  - .DS_Store


### PR DESCRIPTION
This change adds several hidden files and empty folders from the collection tarball that is built with ansible-galaxy. Files were available in the [collection tarball for v2.8.0](https://console.redhat.com/ansible/automation-hub/my-imports/?namespace=cisco&keywords=intersight&page=1).

It would also consider excluding the `misc` folder that contains a PDF. This file is available from GitHub and linked in the README. It probably does not need to be distributed with the collection. However that might be more of a project decision so I didn't include it as part of this pull request.