### PR TITLE
Introduce smtp policy

### DIFF
--- a/plugins/modules/intersight_smtp_policy.py
+++ b/plugins/modules/intersight_smtp_policy.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_smtp_policy
+short_description: SMTP Policy configuration for Cisco Intersight
+description:
+  - Manages SMTP Policy configuration on Cisco Intersight.
+  - Configures SMTP settings for email notifications.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles, Policies, and Pools that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the SMTP Policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  description:
+    description:
+      - The user-defined description for the SMTP Policy.
+      - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
+    type: str
+    aliases: [descr]
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+    default: []
+  enabled:
+    description:
+      - If enabled, controls the state of the SMTP client service on the managed device.
+    type: bool
+    default: true
+  smtp_server:
+    description:
+      - IP address or hostname of the SMTP server.
+      - The SMTP server is used by the managed device to send email notifications.
+      - Required when C(enabled) is True.
+    type: str
+  smtp_port:
+    description:
+      - Port number used by the SMTP server for outgoing SMTP communication.
+      - Valid range is 1-65535.
+    type: int
+    default: 25
+  min_severity:
+    description:
+      - Minimum fault severity level to receive email notifications.
+      - Email notifications are sent for all faults whose severity is equal to or greater than the chosen level.
+    type: str
+    choices: [critical, major, minor, warning, condition, condition]
+    default: critical
+  sender_email:
+    description:
+      - The email address entered here will be displayed as the from address (mail received from address) of all the SMTP mail alerts that are received.
+      - If not configured, the hostname of the server is used in the from address field.
+    type: str
+  smtp_recipients:
+    description:
+      - List of email addresses that will receive notifications for faults.
+    type: list
+    elements: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Create SMTP Policy
+  cisco.intersight.intersight_smtp_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+    name: "smtp-policy-test"
+    description: "SMTP Policy for Alerting"
+    enabled: true
+    smtp_server: "smtp.example.com"
+    smtp_port: 25
+    min_severity: "warning"
+    sender_email: "alerts@example.com"
+    smtp_recipients:
+      - "admin@example.com"
+      - "devops@example.com"
+    tags:
+      - Key: "Environment"
+        Value: "Production"
+    state: present
+
+- name: Disable SMTP Policy
+  cisco.intersight.intersight_smtp_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "smtp-policy-test"
+    enabled: false
+    state: present
+
+- name: Delete SMTP Policy
+  cisco.intersight.intersight_smtp_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "smtp-policy-test"
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "smtp-policy-test",
+        "ObjectType": "smtp.Policy",
+        "Description": "SMTP Policy for Alerting",
+        "Enabled": true,
+        "SmtpServer": "smtp.example.com",
+        "SmtpPort": 25,
+        "MinSeverity": "warning",
+        "SenderEmail": "alerts@example.com",
+        "SmtpRecipients": [
+            "admin@example.com",
+            "devops@example.com"
+        ],
+        "Tags": [
+            {
+                "Key": "Environment",
+                "Value": "Production"
+            }
+        ]
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict', default=[]),
+        enabled=dict(type='bool', default=True),
+        smtp_server=dict(type='str'),
+        smtp_port=dict(type='int', default=25),
+        min_severity=dict(type='str', choices=['critical', 'major', 'minor', 'warning', 'condition', 'condition'], default='critical'),
+        sender_email=dict(type='str'),
+        smtp_recipients=dict(type='list', elements='str')
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    # Build API Body
+    intersight.api_body = {
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+        'Name': intersight.module.params['name']
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+        intersight.api_body['Enabled'] = module.params['enabled']
+        if module.params['enabled']:
+            if not module.params.get('smtp_server'):
+                module.fail_json(msg="smtp_server is required when enabled is True")
+
+            if module.params.get('smtp_server'):
+                intersight.api_body['SmtpServer'] = module.params['smtp_server']
+            if module.params.get('smtp_port'):
+                intersight.api_body['SmtpPort'] = module.params['smtp_port']
+            if module.params.get('min_severity'):
+                intersight.api_body['MinSeverity'] = module.params['min_severity']
+            if module.params.get('sender_email'):
+                intersight.api_body['SenderEmail'] = module.params['sender_email']
+            if module.params.get('smtp_recipients'):
+                intersight.api_body['SmtpRecipients'] = module.params['smtp_recipients']
+
+    resource_path = '/smtp/Policies'
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_smtp_policy_info.py
+++ b/plugins/modules/intersight_smtp_policy_info.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_smtp_policy_info
+short_description: Gather information about SMTP Policies in Cisco Intersight
+description:
+  - Gather information about SMTP Policies in L(Cisco Intersight,https://intersight.com).
+  - Information can be filtered by O(organization) and O(name).
+  - If no filters are passed, all SMTP Policies will be returned.
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the organization the SMTP Policy belongs to.
+    type: str
+  name:
+    description:
+      - The name of the SMTP Policy to gather information from.
+    type: str
+author:
+  - Ron Gershburg (@rgershbu)
+'''
+
+EXAMPLES = r'''
+- name: Fetch a specific SMTP Policy by name
+  cisco.intersight.intersight_smtp_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "smtp-policy-test"
+
+- name: Fetch all SMTP Policies in a specific Organization
+  cisco.intersight.intersight_smtp_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: "default"
+
+- name: Fetch all SMTP Policies
+  cisco.intersight.intersight_smtp_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": [
+      {
+        "Name": "smtp-policy-test",
+        "ObjectType": "smtp.Policy",
+        "Description": "SMTP Policy for Alerting",
+        "Enabled": true,
+        "SmtpServer": "smtp.example.com",
+        "SmtpPort": 25,
+        "MinSeverity": "warning",
+        "SenderEmail": "alerts@example.com",
+        "SmtpRecipients": [
+            "admin@example.com",
+            "devops@example.com"
+        ],
+        "Tags": []
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str'),
+        name=dict(type='str')
+    )
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+    intersight = IntersightModule(module)
+
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/smtp/Policies'
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(
+        resource_path=resource_path,
+        query_params=query_params,
+        return_list=True
+    )
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_smtp_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_smtp_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_smtp_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_smtp_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_smtp_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_smtp_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml

--- a/tests/integration/targets/intersight_smtp_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_smtp_policy/tasks/tests.yml
@@ -1,0 +1,169 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_smtp_policy_minimal
+      - test_smtp_policy_full
+      - test_smtp_policy_disabled
+
+  - name: Create SMTP Policy with minimal parameters (check-mode)
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_minimal
+      description: "Test SMTP Policy Minimal"
+      state: present
+      smtp_server: "smtp.example.com"
+    check_mode: true
+    register: minimal_creation_check_mode
+
+  - name: Verify SMTP Policy was not created (check-mode)
+    ansible.builtin.assert:
+      that:
+        - minimal_creation_check_mode is changed
+        - minimal_creation_check_mode.api_response == {}
+
+  - name: Create SMTP Policy with minimal parameters
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_minimal
+      description: "Test SMTP Policy Minimal"
+      smtp_server: "smtp.example.com"
+      state: present
+    register: minimal_creation
+
+  - name: Fetch info after Minimal SMTP Policy creation
+    cisco.intersight.intersight_smtp_policy_info:
+      <<: *api_info
+      name: test_smtp_policy_minimal
+    register: minimal_info
+
+  - name: Verify Minimal SMTP Policy creation
+    ansible.builtin.assert:
+      that:
+        - minimal_creation.changed
+        - minimal_info.api_response[0].Name == 'test_smtp_policy_minimal'
+        - minimal_info.api_response[0].Enabled == true
+        - minimal_info.api_response[0].SmtpServer == 'smtp.example.com'
+        - minimal_info.api_response[0].SmtpPort == 25
+        - minimal_info.api_response[0].MinSeverity == 'critical'
+
+  - name: Create SMTP Policy with minimal parameters (idempotency check)
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_minimal
+      description: "Test SMTP Policy Minimal"
+      smtp_server: "smtp.example.com"
+      state: present
+    register: minimal_creation_ide
+
+  - name: Verify Minimal SMTP Policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not minimal_creation_ide.changed
+
+  - name: Create SMTP Policy with full parameters
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_full
+      description: "Test SMTP Policy Full"
+      enabled: true
+      smtp_server: "1.2.3.4"
+      smtp_port: 2525
+      min_severity: "warning"
+      sender_email: "sender@example.com"
+      smtp_recipients:
+        - "user1@example.com"
+        - "user2@example.com"
+      tags:
+        - Key: Environment
+          Value: Test
+      state: present
+    register: full_creation
+
+  - name: Fetch info after Full SMTP Policy creation
+    cisco.intersight.intersight_smtp_policy_info:
+      <<: *api_info
+      name: test_smtp_policy_full
+    register: full_info
+
+  - name: Verify Full SMTP Policy creation
+    ansible.builtin.assert:
+      that:
+        - full_creation.changed
+        - full_info.api_response[0].Name == 'test_smtp_policy_full'
+        - full_info.api_response[0].Enabled == true
+        - full_info.api_response[0].SmtpServer == '1.2.3.4'
+        - full_info.api_response[0].SmtpPort == 2525
+        - full_info.api_response[0].MinSeverity == 'warning'
+        - full_info.api_response[0].SenderEmail == 'sender@example.com'
+        - full_info.api_response[0].SmtpRecipients | length == 2
+
+  - name: Update SMTP Policy
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_full
+      description: "Updated Description"
+      min_severity: "major"
+      smtp_server: "1.2.3.4"
+      smtp_recipients:
+        - "user3@example.com"
+    register: policy_update
+
+  - name: Fetch info after Update
+    cisco.intersight.intersight_smtp_policy_info:
+      <<: *api_info
+      name: test_smtp_policy_full
+    register: update_info
+
+  - name: Verify Update
+    ansible.builtin.assert:
+      that:
+        - policy_update.changed
+        - update_info.api_response[0].Description == 'Updated Description'
+        - update_info.api_response[0].MinSeverity == 'major'
+        - update_info.api_response[0].SmtpRecipients | length == 1
+        - update_info.api_response[0].SmtpRecipients[0] == 'user3@example.com'
+
+  - name: Create Disabled SMTP Policy
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: test_smtp_policy_disabled
+      enabled: false
+      state: present
+    register: disabled_creation
+
+  - name: Verify Disabled SMTP Policy
+    cisco.intersight.intersight_smtp_policy_info:
+      <<: *api_info
+      name: test_smtp_policy_disabled
+    register: disabled_info
+
+  - name: Verify Disabled status
+    ansible.builtin.assert:
+      that:
+        - disabled_creation.changed
+        - disabled_info.api_response[0].Enabled == false
+
+  always:
+  - name: Remove all test SMTP Policies
+    cisco.intersight.intersight_smtp_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_smtp_policy_minimal
+      - test_smtp_policy_full
+      - test_smtp_policy_disabled


### PR DESCRIPTION
#### SUMMARY
- Create  smtp policy modules on Cisco UCS via Cisco Intersight Using Ansible Module
#### ISSUE TYPE
- New Module Pull Request
#### COMPONENT NAME
- plugins/modules/intersight_ smtp_policy.py
- plugins/modules/intersight_smtp_policy_info.py
#### ADDITIONAL INFORMATION
- Added integration tests