### PR TITLE
fix: add IPMI/Local account type support to local user policy

### DIFF
--- a/plugins/modules/intersight_local_user_policy.py
+++ b/plugins/modules/intersight_local_user_policy.py
@@ -104,6 +104,26 @@ options:
           - Valid login password of the user.
         type: str
         required: true
+      endpoint_role_type:
+        description:
+          - The type of endpoint role to assign to the user.
+          - IMC is the default server management role type.
+          - IPMI enables IPMI access for the user.
+        type: str
+        choices: [IMC, IPMI]
+        default: IMC
+      account_type_user_defined:
+        description:
+          - If true, account types are user-defined rather than derived from the endpoint role.
+          - Should be set to true when specifying custom account_types.
+        type: bool
+        default: false
+      account_types:
+        description:
+          - List of account type objects to assign to the user.
+          - Each entry must include an ObjectType key (e.g., iam.AccountTypeIpmi).
+        type: list
+        elements: dict
   purge:
     description:
       - The purge argument instructs the module to consider the resource definition absolute.
@@ -138,6 +158,21 @@ EXAMPLES = r'''
       - username: reader
         role: readonly
         password: vault_reader_password
+
+- name: Configure Local User policy with IPMI user
+  intersight_local_user_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: ipmi-admin
+    description: User with IPMI account type
+    local_users:
+      - username: ipmi-user
+        role: admin
+        password: vault_ipmi_password
+        endpoint_role_type: IPMI
+        account_type_user_defined: true
+        account_types:
+          - ObjectType: iam.AccountTypeIpmi
 
 - name: Delete Local User policy
   intersight_local_user_policy:
@@ -175,6 +210,9 @@ def main():
         enable=dict(type='bool', default=True),
         role=dict(type='str', choices=['admin', 'readonly', 'user'], required=True),
         password=dict(type='str', required=True, no_log=True),
+        endpoint_role_type=dict(type='str', choices=['IMC', 'IPMI'], default='IMC'),
+        account_type_user_defined=dict(type='bool', default=False),
+        account_types=dict(type='list', elements='dict'),
     )
     argument_spec = intersight_argument_spec.copy()
     argument_spec.update(
@@ -254,7 +292,7 @@ def main():
                         'EndPointRole': [
                             {
                                 'Name': user['role'],
-                                'Type': 'IMC',
+                                'Type': user.get('endpoint_role_type', 'IMC'),
                             },
                         ],
                         'EndPointUser': {
@@ -342,7 +380,7 @@ def main():
                 intersight.get_resource(
                     resource_path='/iam/EndPointRoles',
                     query_params={
-                        '$filter': "Name eq '" + user['role'] + "' and Type eq 'IMC'",
+                        '$filter': "Name eq '" + user['role'] + "' and Type eq '" + user.get('endpoint_role_type', 'IMC') + "'",
                     },
                 )
                 end_point_role_moid = None
@@ -365,6 +403,10 @@ def main():
                         'Moid': user_policy_moid,
                     },
                 }
+                if user.get('account_type_user_defined'):
+                    intersight.api_body['IsAccountTypeUserDefined'] = True
+                if user.get('account_types'):
+                    intersight.api_body['AccountTypes'] = user['account_types']
                 intersight.configure_resource(
                     moid=None,
                     resource_path='/iam/EndPointUserRoles',


### PR DESCRIPTION
## Summary

- Adds `endpoint_role_type`, `account_type_user_defined`, and `account_types` suboptions to the `local_users` parameter in `intersight_local_user_policy`
- Replaces the hardcoded `'IMC'` EndPointRole type with the user-specified `endpoint_role_type` (defaults to `IMC` for backward compatibility)
- Passes `IsAccountTypeUserDefined` and `AccountTypes` to the EndPointUserRole API body when specified

Fixes #309

## Changes

The `EndPointRole` type was hardcoded to `'IMC'` in two places in `intersight_local_user_policy.py`, preventing users from configuring IPMI account types. This PR:

1. **Adds three new `local_users` suboptions:**
   - `endpoint_role_type` (str, choices: `IMC`/`IPMI`, default: `IMC`) — selects the EndPointRole type
   - `account_type_user_defined` (bool, default: `false`) — enables user-defined account types
   - `account_types` (list of dicts) — account type objects (e.g., `ObjectType: iam.AccountTypeIpmi`)

2. **Updates the comparison logic** (line ~295) to use `endpoint_role_type` instead of hardcoded `'IMC'`

3. **Updates the EndPointRole filter query** (line ~383) to use `endpoint_role_type` instead of hardcoded `'IMC'`

4. **Adds `IsAccountTypeUserDefined` and `AccountTypes`** to the EndPointUserRole configuration body when specified

### Example usage

```yaml
local_users:
  - username: ipmi-user
    role: admin
    password: vault_ipmi_password
    endpoint_role_type: IPMI
    account_type_user_defined: true
    account_types:
      - ObjectType: iam.AccountTypeIpmi
```

## Test plan

- [ ] Verify existing playbooks without new parameters continue to work unchanged (backward compatible — defaults to `IMC`)
- [ ] Create a local user policy with `endpoint_role_type: IPMI` and confirm the EndPointRole lookup succeeds
- [ ] Verify `account_types` and `account_type_user_defined` are correctly passed in the API body
- [ ] Confirm idempotency check works correctly with the new `endpoint_role_type` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)