### PR TITLE
feat: add assignment_order option to all pool modules

### DIFF
--- a/plugins/modules/intersight_ip_pool.py
+++ b/plugins/modules/intersight_ip_pool.py
@@ -50,6 +50,14 @@ options:
       - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
     type: str
     aliases: [descr]
+  assignment_order:
+    description:
+      - Assignment order decides the order in which the next identifier is allocated.
+      - If C(sequential), identifiers are assigned in a sequential order.
+      - If C(default), the system determines the assignment order.
+    type: str
+    choices: [default, sequential]
+    default: default
   enable_block_level_subnet_config:
     description:
       - Determines if the "Netmask", "Gateway", "PrimaryDns" and "SecondaryDns" is globally defined or specified per IPv4 block.
@@ -194,6 +202,7 @@ EXAMPLES = r'''
     organization: DevNet
     name: lab-ip-pool
     description: IP Pool for lab use
+    assignment_order: sequential
     ipv4_config:
       netmask: "255.255.255.0"
       gateway: "172.17.116.1"
@@ -329,6 +338,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
+        assignment_order=dict(type='str', choices=['default', 'sequential'], default='default'),
         enable_block_level_subnet_config=dict(type='bool', default=False),
         ipv4_config=dict(type='dict'),
         ipv4_blocks=dict(type='list', elements='dict'),
@@ -358,6 +368,7 @@ def main():
 
     if module.params['state'] == 'present':
         intersight.set_tags_and_description()
+        intersight.api_body['AssignmentOrder'] = intersight.module.params['assignment_order']
 
         # Validate that at least one of ipv4_blocks/ipv6_blocks was passed. We don't mark it as required in order to support absent.
         if not intersight.module.params['ipv4_blocks'] and not intersight.module.params['ipv6_blocks']:

--- a/plugins/modules/intersight_iqn_pool.py
+++ b/plugins/modules/intersight_iqn_pool.py
@@ -50,6 +50,14 @@ options:
       - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
     type: str
     aliases: [descr]
+  assignment_order:
+    description:
+      - Assignment order decides the order in which the next identifier is allocated.
+      - If C(sequential), identifiers are assigned in a sequential order.
+      - If C(default), the system determines the assignment order.
+    type: str
+    choices: [default, sequential]
+    default: default
   prefix:
     description:
       - The prefix for any IQN blocks created for this pool.
@@ -91,6 +99,7 @@ EXAMPLES = r'''
     api_key_id: "{{ api_key_id }}"
     name: iqn_pool_1
     description: "Test iqn pool description"
+    assignment_order: sequential
     tags:
       - "Key": "Site"
         "Value": "tag1"
@@ -145,6 +154,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
+        assignment_order=dict(type='str', choices=['default', 'sequential'], default='default'),
         prefix=dict(type='str'),
         iqn_suffix_blocks=dict(
             type='list',
@@ -175,6 +185,7 @@ def main():
     iqn_suffix_blocks_dict = []
     if module.params['state'] == 'present':
         intersight.set_tags_and_description()
+        intersight.api_body['AssignmentOrder'] = intersight.module.params['assignment_order']
         # Validate that iqn_suffix_blocks was passed. We don't mark it as required in order to support absent.
         if not intersight.module.params['iqn_suffix_blocks']:
             module.fail_json(msg="iqn_suffix_blocks parameter must be provided and contain at least one block when state is 'present'.")

--- a/plugins/modules/intersight_mac_pool.py
+++ b/plugins/modules/intersight_mac_pool.py
@@ -50,6 +50,14 @@ options:
       - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
     type: str
     aliases: [descr]
+  assignment_order:
+    description:
+      - Assignment order decides the order in which the next identifier is allocated.
+      - If C(sequential), identifiers are assigned in a sequential order.
+      - If C(default), the system determines the assignment order.
+    type: str
+    choices: [default, sequential]
+    default: default
   mac_blocks:
     description:
       - List of the MAC blocks.
@@ -80,6 +88,7 @@ EXAMPLES = r'''
     api_key_id: "{{ api_key_id }}"
     name: mac_pool_1
     description: "Test mac pool description"
+    assignment_order: sequential
     tags:
       - "Key": "Site"
         "Value": "tag1"
@@ -131,6 +140,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
+        assignment_order=dict(type='str', choices=['default', 'sequential'], default='default'),
         mac_blocks=dict(
             type='list',
             elements='dict',
@@ -161,6 +171,7 @@ def main():
     mac_blocks_dict = []
     if module.params['state'] == 'present':
         intersight.set_tags_and_description()
+        intersight.api_body['AssignmentOrder'] = intersight.module.params['assignment_order']
 
         # Validate that mac_blocks was passed. We don't mark it as required in order to support absent.
         if not intersight.module.params['mac_blocks']:

--- a/plugins/modules/intersight_uuid_pool.py
+++ b/plugins/modules/intersight_uuid_pool.py
@@ -51,6 +51,14 @@ options:
       - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
     type: str
     aliases: [descr]
+  assignment_order:
+    description:
+      - Assignment order decides the order in which the next identifier is allocated.
+      - If C(sequential), identifiers are assigned in a sequential order.
+      - If C(default), the system determines the assignment order.
+    type: str
+    choices: [default, sequential]
+    default: default
   prefix:
     description:
       - The UUID prefix used for all UUID suffix blocks.
@@ -91,6 +99,7 @@ EXAMPLES = r'''
     organization: DevNet
     name: lab-uuid-pool
     description: UUID Pool for lab use
+    assignment_order: sequential
     prefix: "550E8400-E29B-41D4"
     uuid_suffix_blocks:
       - from: "A716-446655440000"
@@ -194,6 +203,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
+        assignment_order=dict(type='str', choices=['default', 'sequential'], default='default'),
         prefix=dict(type='str'),
         uuid_suffix_blocks=dict(type='list', elements='dict'),
     )
@@ -232,6 +242,7 @@ def main():
     }
     if module.params['state'] == 'present':
         intersight.set_tags_and_description()
+        intersight.api_body['AssignmentOrder'] = intersight.module.params['assignment_order']
         intersight.api_body['Prefix'] = intersight.module.params['prefix']
         UuidSuffixBlocks = []
         for uuid_block in intersight.module.params['uuid_suffix_blocks']:

--- a/plugins/modules/intersight_wwn_pool.py
+++ b/plugins/modules/intersight_wwn_pool.py
@@ -51,6 +51,14 @@ options:
       - Description can contain letters(a-z, A-Z), numbers(0-9), hyphen(-), period(.), colon(:), or an underscore(_).
     type: str
     aliases: [descr]
+  assignment_order:
+    description:
+      - Assignment order decides the order in which the next identifier is allocated.
+      - If C(sequential), identifiers are assigned in a sequential order.
+      - If C(default), the system determines the assignment order.
+    type: str
+    choices: [default, sequential]
+    default: default
   pool_purpose:
     description:
       - The pool type WWNN or WWPN.
@@ -89,6 +97,7 @@ EXAMPLES = r'''
     api_key_id: "{{ api_key_id }}"
     name: wwn_pool_1
     description: "Test WWNN pool description"
+    assignment_order: sequential
     tags:
       - "Key": "Site"
         "Value": "tag1"
@@ -176,6 +185,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
+        assignment_order=dict(type='str', choices=['default', 'sequential'], default='default'),
         pool_purpose=dict(type='str', required=True),
         id_blocks=dict(
             type='list',
@@ -205,6 +215,7 @@ def main():
     id_blocks_dict = []
     if module.params['state'] == 'present':
         intersight.set_tags_and_description()
+        intersight.api_body['AssignmentOrder'] = intersight.module.params['assignment_order']
         # Validate that required parameters were passed. We don't mark it as required in order to support absent.
         if not intersight.module.params['id_blocks']:
             module.fail_json(msg="wwn id_blocks parameter must be provided and contain at least one block when state is 'present'.")


### PR DESCRIPTION
## Summary

- Adds `assignment_order` parameter (`default` or `sequential`) to all five pool modules: `intersight_ip_pool`, `intersight_iqn_pool`, `intersight_mac_pool`, `intersight_uuid_pool`, and `intersight_wwn_pool`
- Defaults to `default` for full backward compatibility
- Sets `AssignmentOrder` in the Intersight API body when creating or updating pools

Fixes #308

## Details

Customers commonly want pool identifiers (MAC, IP, UUID, IQN, WWN) assigned in sequential/numerical order rather than the system default. The Intersight API supports this via the `AssignmentOrder` field on all pool resources, but the Ansible modules did not expose it.

This PR adds the `assignment_order` option to each pool module's:
1. **DOCUMENTATION** — option description with choices and default
2. **EXAMPLES** — shows `assignment_order: sequential` usage
3. **argument_spec** — validated string with choices `[default, sequential]`
4. **api_body** — maps to `AssignmentOrder` in the API payload (only when `state=present`)

### Example usage

```yaml
- name: Create MAC pool with sequential assignment
  cisco.intersight.intersight_mac_pool:
    api_private_key: "{{ api_private_key }}"
    api_key_id: "{{ api_key_id }}"
    name: mac_pool_1
    assignment_order: sequential
    mac_blocks:
      - address_from: "00:25:B5:00:00:00"
        size: 20
```

## Test plan

- [ ] Verify existing playbooks without `assignment_order` continue to work (backward compatible — defaults to `default`)
- [ ] Create a pool with `assignment_order: sequential` and confirm the API response shows `"AssignmentOrder": "sequential"`
- [ ] Verify idempotency: re-running with the same `assignment_order` value reports no changes
- [ ] Confirm invalid values are rejected by Ansible's argument validation (e.g., `assignment_order: random` fails)
- [ ] Test across all five pool types: IP, IQN, MAC, UUID, WWN

🤖 Generated with [Claude Code](https://claude.com/claude-code)