### PR TITLE
feat: add AI compute modules (GPU, BIOS tuning, confidential compute)

### DIFF
--- a/plugins/modules/intersight_bios_ai_tuning.py
+++ b/plugins/modules/intersight_bios_ai_tuning.py
@@ -1,0 +1,340 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_bios_ai_tuning
+short_description: AI-optimized BIOS policy presets for Cisco Intersight
+description:
+  - Creates BIOS policies with pre-validated settings optimized for AI and GPU workloads.
+  - Provides named tuning profiles that set multiple BIOS knobs at once for common AI use cases.
+  - Profiles target NVIDIA H100/B200 GPU servers and Intel/AMD CPU platforms used in Cisco AI Factory.
+  - Individual BIOS knobs can be overridden after the preset is applied.
+  - For full BIOS knob control, use M(cisco.intersight.intersight_bios_policy) instead.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles and Policies that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the BIOS policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  description:
+    description:
+      - The user-defined description of the BIOS policy.
+    type: str
+    aliases: [descr]
+  tuning_profile:
+    description:
+      - The AI tuning profile preset to apply.
+      - C(gpu_inference) optimizes for maximum GPU throughput with low-latency memory access.
+        Sets GPU ACS control enabled, NUMA optimized, hardware P-states disabled for consistent
+        performance, SR-IOV enabled, and memory interleave optimized.
+      - C(gpu_training) optimizes for large-scale GPU training workloads with maximum memory
+        bandwidth. Includes all gpu_inference settings plus maximum power performance tuning,
+        workload configuration set to balanced, and package C-state limit for sustained throughput.
+      - C(cpu_inference) optimizes for CPU-based inference with low-latency tuning.
+        Enables hardware P-states for native performance, Intel Turbo Boost, LLC prefetch,
+        and NUMA optimization without GPU-specific settings.
+      - C(edge_ai) optimizes for Cisco Unified Edge nodes with power-aware AI tuning.
+        Balances performance with power efficiency using energy-efficient turbo, hardware P-states,
+        and NUMA optimization suitable for edge deployment constraints.
+    type: str
+    choices: [gpu_inference, gpu_training, cpu_inference, edge_ai]
+    required: true
+  gpu_count:
+    description:
+      - Number of GPUs to enable via ACS Control (1-8).
+      - Only applicable for gpu_inference and gpu_training profiles.
+      - GPUs beyond this count will have ACS control set to platform-default.
+    type: int
+    default: 8
+  numa_optimized:
+    description:
+      - Override the NUMA optimization setting from the tuning profile.
+    type: str
+    choices: [platform-default, enabled, disabled]
+  cpu_power_management:
+    description:
+      - Override the CPU power management setting from the tuning profile.
+    type: str
+    choices: [platform-default, performance, energy-efficient, custom]
+  sriov:
+    description:
+      - Override the SR-IOV setting from the tuning profile.
+      - SR-IOV is required for GPU passthrough in virtualized environments.
+    type: str
+    choices: [platform-default, enabled, disabled]
+  intel_turbo_boost_tech:
+    description:
+      - Override the Intel Turbo Boost Technology setting.
+    type: str
+    choices: [platform-default, enabled, disabled]
+  cpu_performance:
+    description:
+      - Override the CPU performance setting from the tuning profile.
+    type: str
+    choices: [platform-default, custom, enterprise, high-throughput, hpc]
+  cpu_energy_performance:
+    description:
+      - Override the CPU energy performance bias setting.
+    type: str
+    choices: [platform-default, balanced-energy, balanced-performance, energy-efficient, performance]
+author:
+  - Steve Fulmer (@stevefulme1)
+'''
+
+EXAMPLES = r'''
+- name: Create GPU inference optimized BIOS policy for 8-GPU server
+  cisco.intersight.intersight_bios_ai_tuning:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: AI-Factory
+    name: bios-gpu-inference-h100
+    description: BIOS tuning for H100 GPU inference servers
+    tuning_profile: gpu_inference
+    gpu_count: 8
+
+- name: Create GPU training BIOS policy with power override
+  cisco.intersight.intersight_bios_ai_tuning:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-gpu-training
+    tuning_profile: gpu_training
+    cpu_power_management: performance
+
+- name: Create CPU inference BIOS policy for non-GPU workloads
+  cisco.intersight.intersight_bios_ai_tuning:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-cpu-inference
+    tuning_profile: cpu_inference
+    intel_turbo_boost_tech: enabled
+
+- name: Create edge AI BIOS policy for Unified Edge nodes
+  cisco.intersight.intersight_bios_ai_tuning:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-edge-ai
+    tuning_profile: edge_ai
+    gpu_count: 2
+
+- name: Delete AI BIOS policy
+  cisco.intersight.intersight_bios_ai_tuning:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-gpu-inference-h100
+    tuning_profile: gpu_inference
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "bios-gpu-inference-h100",
+        "ObjectType": "bios.Policy",
+        "NumaOptimized": "enabled",
+        "AcsControlGpu1state": "enabled"
+    }
+applied_settings:
+  description: The BIOS settings applied by the tuning profile and any overrides.
+  returned: when state is present
+  type: dict
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+# AI tuning profile presets
+# Each profile maps Intersight BIOS API property names to their values.
+TUNING_PROFILES = {
+    'gpu_inference': {
+        # NUMA and memory optimization
+        'NumaOptimized': 'enabled',
+        'CbsDfCmnAcpiSratL3numa': 'enabled',
+        # CPU performance - disable P-states for consistent GPU-driven latency
+        'CpuPowerManagement': 'performance',
+        'CpuPerformance': 'high-throughput',
+        'CpuEnergyPerformance': 'performance',
+        'PackageCstateLimit': 'C0 C1 State',
+        'AutonomousCstateEnable': 'disabled',
+        'CpuHwpm': 'Disabled',
+        # GPU and I/O
+        'SrIov': 'enabled',
+        'AcsControlSlot11state': 'enabled',
+        'AcsControlSlot12state': 'enabled',
+        'AcsControlSlot13state': 'enabled',
+        'AcsControlSlot14state': 'enabled',
+        # Memory performance
+        'LlcPrefetch': 'enabled',
+        'XptPrefetch': 'enabled',
+    },
+    'gpu_training': {
+        # All gpu_inference settings plus maximum power
+        'NumaOptimized': 'enabled',
+        'CbsDfCmnAcpiSratL3numa': 'enabled',
+        'CpuPowerManagement': 'performance',
+        'CpuPerformance': 'high-throughput',
+        'CpuEnergyPerformance': 'performance',
+        'PackageCstateLimit': 'C0 C1 State',
+        'AutonomousCstateEnable': 'disabled',
+        'CpuHwpm': 'Disabled',
+        'SrIov': 'enabled',
+        'AcsControlSlot11state': 'enabled',
+        'AcsControlSlot12state': 'enabled',
+        'AcsControlSlot13state': 'enabled',
+        'AcsControlSlot14state': 'enabled',
+        'LlcPrefetch': 'enabled',
+        'XptPrefetch': 'enabled',
+        # Training-specific: maximum power and bandwidth
+        'WorkloadConfig': 'Balanced',
+    },
+    'cpu_inference': {
+        # CPU-optimized for inference without GPU focus
+        'NumaOptimized': 'enabled',
+        'CbsDfCmnAcpiSratL3numa': 'enabled',
+        'CpuPowerManagement': 'performance',
+        'CpuPerformance': 'high-throughput',
+        'CpuEnergyPerformance': 'performance',
+        'IntelTurboBoostTech': 'enabled',
+        'CpuHwpm': 'HWPM Native Mode',
+        'LlcPrefetch': 'enabled',
+        'XptPrefetch': 'enabled',
+    },
+    'edge_ai': {
+        # Power-aware AI tuning for edge nodes
+        'NumaOptimized': 'enabled',
+        'CpuPowerManagement': 'energy-efficient',
+        'CpuPerformance': 'enterprise',
+        'CpuEnergyPerformance': 'balanced-performance',
+        'EnergyEfficientTurbo': 'enabled',
+        'IntelTurboBoostTech': 'enabled',
+        'CpuHwpm': 'HWPM Native Mode',
+        'LlcPrefetch': 'enabled',
+    },
+}
+
+# GPU ACS control API property names by slot index (1-8)
+GPU_ACS_PROPERTIES = [
+    'AcsControlGpu1state',
+    'AcsControlGpu2state',
+    'AcsControlGpu3state',
+    'AcsControlGpu4state',
+    'AcsControlGpu5state',
+    'AcsControlGpu6state',
+    'AcsControlGpu7state',
+    'AcsControlGpu8state',
+]
+
+# Map of override parameter names to API property names
+OVERRIDE_MAP = {
+    'numa_optimized': 'NumaOptimized',
+    'cpu_power_management': 'CpuPowerManagement',
+    'sriov': 'SrIov',
+    'intel_turbo_boost_tech': 'IntelTurboBoostTech',
+    'cpu_performance': 'CpuPerformance',
+    'cpu_energy_performance': 'CpuEnergyPerformance',
+}
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        tuning_profile=dict(type='str', choices=['gpu_inference', 'gpu_training', 'cpu_inference', 'edge_ai'], required=True),
+        gpu_count=dict(type='int', default=8),
+        numa_optimized=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
+        cpu_power_management=dict(type='str', choices=['platform-default', 'performance', 'energy-efficient', 'custom']),
+        sriov=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
+        intel_turbo_boost_tech=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
+        cpu_performance=dict(type='str', choices=['platform-default', 'custom', 'enterprise', 'high-throughput', 'hpc']),
+        cpu_energy_performance=dict(
+            type='str',
+            choices=['platform-default', 'balanced-energy', 'balanced-performance', 'energy-efficient', 'performance']
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/bios/Policies'
+
+    intersight.api_body = {
+        'Name': intersight.module.params['name'],
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+
+        # Apply tuning profile preset
+        profile_name = module.params['tuning_profile']
+        profile_settings = TUNING_PROFILES[profile_name].copy()
+
+        # Apply GPU ACS control based on gpu_count for GPU profiles
+        if profile_name in ('gpu_inference', 'gpu_training'):
+            gpu_count = min(max(module.params['gpu_count'], 0), 8)
+            for i, prop in enumerate(GPU_ACS_PROPERTIES):
+                profile_settings[prop] = 'enabled' if i < gpu_count else 'platform-default'
+
+        # Apply user overrides
+        for param_name, api_property in OVERRIDE_MAP.items():
+            if module.params.get(param_name) is not None:
+                profile_settings[api_property] = module.params[param_name]
+
+        intersight.api_body.update(profile_settings)
+        intersight.result['applied_settings'] = profile_settings
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_confidential_compute.py
+++ b/plugins/modules/intersight_confidential_compute.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_confidential_compute
+short_description: Confidential computing BIOS policy for Cisco Intersight
+description:
+  - Creates BIOS policies with hardware-level confidential computing features enabled.
+  - Supports AMD SEV (Secure Encrypted Virtualization), AMD SEV-SNP, and Intel SGX
+    (Software Guard Extensions) for secure AI enclaves.
+  - Combines the correct BIOS knob settings needed to enable memory encryption and
+    trusted execution environments on Cisco UCS servers.
+  - Intended for AI workloads that require protection of proprietary model data in memory.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles and Policies that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the BIOS policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  description:
+    description:
+      - The user-defined description of the BIOS policy.
+    type: str
+    aliases: [descr]
+  security_profile:
+    description:
+      - The confidential computing security profile to apply.
+      - C(amd_sev) enables AMD Secure Encrypted Virtualization with memory encryption for VMs.
+        Encrypts VM memory with per-VM keys so the hypervisor cannot read guest data.
+        Requires AMD EPYC processors (Milan/Genoa or later).
+      - C(amd_sev_snp) enables AMD SEV with Secure Nested Paging for stronger isolation.
+        Adds integrity protection on top of SEV memory encryption, preventing hypervisor
+        tampering with guest memory mappings. Requires AMD EPYC Genoa or later.
+      - C(intel_sgx) enables Intel Software Guard Extensions for application-level enclaves.
+        Creates hardware-encrypted memory enclaves that protect specific application data
+        even from the OS and hypervisor. Requires Intel Xeon Scalable (Ice Lake or later).
+      - C(intel_sgx_with_auto_reg) enables Intel SGX with automatic registration agent.
+        Includes all intel_sgx settings plus enables the SGX auto-registration agent for
+        simplified attestation service enrollment.
+    type: str
+    choices: [amd_sev, amd_sev_snp, intel_sgx, intel_sgx_with_auto_reg]
+    required: true
+  sev_asid_count:
+    description:
+      - Number of AMD SEV Address Space Identifiers (ASIDs) to allocate.
+      - Higher ASID counts allow more concurrent encrypted VMs but may reduce available ASIDs for SEV-SNP.
+      - Only applicable for amd_sev and amd_sev_snp security profiles.
+    type: str
+    choices: [platform-default, '253 ASIDs', '509 ASIDs']
+  sgx_epoch0:
+    description:
+      - Intel SGX Epoch 0 value. Changing this invalidates all existing SGX sealed data.
+      - Only applicable for intel_sgx and intel_sgx_with_auto_reg profiles.
+      - Use with caution in production environments.
+    type: str
+  sgx_epoch1:
+    description:
+      - Intel SGX Epoch 1 value. Changing this invalidates all existing SGX sealed data.
+      - Only applicable for intel_sgx and intel_sgx_with_auto_reg profiles.
+      - Use with caution in production environments.
+    type: str
+  enable_tme:
+    description:
+      - Override for Intel Total Memory Encryption (TME).
+      - TME is a prerequisite for SGX and encrypts all system memory with a platform key.
+      - Automatically enabled by intel_sgx profiles; set explicitly only to override.
+    type: str
+    choices: [platform-default, enabled, disabled]
+  numa_optimized:
+    description:
+      - Override for NUMA optimization.
+      - All confidential compute profiles enable NUMA optimization by default.
+    type: str
+    choices: [platform-default, enabled, disabled]
+author:
+  - Steve Fulmer (@stevefulme1)
+'''
+
+EXAMPLES = r'''
+- name: Create AMD SEV policy for encrypted AI VMs
+  cisco.intersight.intersight_confidential_compute:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: AI-Factory
+    name: bios-amd-sev-ai
+    description: AMD SEV for secure AI inference VMs
+    security_profile: amd_sev
+    sev_asid_count: "509 ASIDs"
+
+- name: Create AMD SEV-SNP policy for maximum VM isolation
+  cisco.intersight.intersight_confidential_compute:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-sev-snp-training
+    description: SEV-SNP for secure model training
+    security_profile: amd_sev_snp
+
+- name: Create Intel SGX policy for enclave-based inference
+  cisco.intersight.intersight_confidential_compute:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-sgx-inference
+    description: SGX enclaves for confidential inference
+    security_profile: intel_sgx_with_auto_reg
+
+- name: Delete confidential compute policy
+  cisco.intersight.intersight_confidential_compute:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: bios-amd-sev-ai
+    security_profile: amd_sev
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "bios-amd-sev-ai",
+        "ObjectType": "bios.Policy",
+        "Sev": "509 ASIDs",
+        "CbsSevSnpSupport": "enabled"
+    }
+applied_settings:
+  description: The BIOS settings applied by the security profile and any overrides.
+  returned: when state is present
+  type: dict
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+# Confidential computing security profile presets
+SECURITY_PROFILES = {
+    'amd_sev': {
+        # AMD SEV - memory encryption for VMs
+        'Sev': '509 ASIDs',
+        # NUMA optimization for consistent memory locality
+        'NumaOptimized': 'enabled',
+        # IOMMU required for SEV
+        'CbsDfCmnDramNps': 'Auto',
+        # SMT enabled for VM density
+        'CpuHwpm': 'HWPM Native Mode',
+    },
+    'amd_sev_snp': {
+        # AMD SEV-SNP - memory encryption + integrity protection
+        'Sev': '509 ASIDs',
+        'CbsSevSnpSupport': 'enabled',
+        'NumaOptimized': 'enabled',
+        'CbsDfCmnDramNps': 'Auto',
+        'CpuHwpm': 'HWPM Native Mode',
+    },
+    'intel_sgx': {
+        # Intel SGX - application-level enclaves
+        'EnableSgx': 'enabled',
+        'EnableTme': 'enabled',
+        'NumaOptimized': 'enabled',
+        'CpuHwpm': 'HWPM Native Mode',
+    },
+    'intel_sgx_with_auto_reg': {
+        # Intel SGX with auto-registration for attestation
+        'EnableSgx': 'enabled',
+        'EnableTme': 'enabled',
+        'SgxAutoRegistrationAgent': 'enabled',
+        'NumaOptimized': 'enabled',
+        'CpuHwpm': 'HWPM Native Mode',
+    },
+}
+
+# Map of override parameter names to API property names
+OVERRIDE_MAP = {
+    'enable_tme': 'EnableTme',
+    'numa_optimized': 'NumaOptimized',
+}
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        security_profile=dict(
+            type='str',
+            choices=['amd_sev', 'amd_sev_snp', 'intel_sgx', 'intel_sgx_with_auto_reg'],
+            required=True,
+        ),
+        sev_asid_count=dict(type='str', choices=['platform-default', '253 ASIDs', '509 ASIDs']),
+        sgx_epoch0=dict(type='str'),
+        sgx_epoch1=dict(type='str'),
+        enable_tme=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
+        numa_optimized=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/bios/Policies'
+
+    intersight.api_body = {
+        'Name': intersight.module.params['name'],
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+
+        # Apply security profile preset
+        profile_name = module.params['security_profile']
+        profile_settings = SECURITY_PROFILES[profile_name].copy()
+
+        # Apply SEV ASID count override for AMD profiles
+        if module.params.get('sev_asid_count') is not None and profile_name in ('amd_sev', 'amd_sev_snp'):
+            profile_settings['Sev'] = module.params['sev_asid_count']
+
+        # Apply SGX epoch overrides for Intel profiles
+        if profile_name in ('intel_sgx', 'intel_sgx_with_auto_reg'):
+            if module.params.get('sgx_epoch0') is not None:
+                profile_settings['SgxEpoch0'] = module.params['sgx_epoch0']
+            if module.params.get('sgx_epoch1') is not None:
+                profile_settings['SgxEpoch1'] = module.params['sgx_epoch1']
+
+        # Apply generic overrides
+        for param_name, api_property in OVERRIDE_MAP.items():
+            if module.params.get(param_name) is not None:
+                profile_settings[api_property] = module.params[param_name]
+
+        intersight.api_body.update(profile_settings)
+        intersight.result['applied_settings'] = profile_settings
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_gpu_policy.py
+++ b/plugins/modules/intersight_gpu_policy.py
@@ -1,0 +1,255 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_gpu_policy
+short_description: GPU policy configuration for Cisco Intersight
+description:
+  - GPU policy configuration for Cisco Intersight.
+  - Used to configure Multi-Instance GPU (MIG) partitioning and GPU assignment on server profiles.
+  - Supports NVIDIA H100, B200, and other MIG-capable GPUs managed through Intersight.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  state:
+    description:
+      - If C(present), will verify the resource is present and will create if needed.
+      - If C(absent), will verify the resource is absent and will delete if needed.
+    type: str
+    choices: [present, absent]
+    default: present
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+      - Profiles and Policies that are created within a Custom Organization are applicable only to devices in the same Organization.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the GPU policy.
+      - The name must be between 1 and 62 alphanumeric characters, allowing special characters :-_.
+    type: str
+    required: true
+  tags:
+    description:
+      - List of tags in Key:<user-defined key> Value:<user-defined value> format.
+    type: list
+    elements: dict
+  description:
+    description:
+      - The user-defined description of the GPU policy.
+    type: str
+    aliases: [descr]
+  gpu_mode:
+    description:
+      - The operating mode for GPUs in the server.
+      - C(graphics) configures GPUs for standard graphics/display use.
+      - C(compute) configures GPUs for compute workloads (CUDA, inference, training).
+    type: str
+    choices: [graphics, compute]
+    default: compute
+  mig_enabled:
+    description:
+      - Enable or disable Multi-Instance GPU (MIG) partitioning.
+      - When enabled, each physical GPU can be partitioned into multiple isolated GPU instances.
+      - MIG is supported on NVIDIA A100, H100, B200 and newer architectures.
+    type: bool
+    default: false
+  mig_profiles:
+    description:
+      - List of MIG partition profiles to apply when mig_enabled is true.
+      - Each entry defines the partition configuration for a GPU slot.
+      - If fewer profiles are specified than available GPUs, remaining GPUs use the default profile.
+    type: list
+    elements: dict
+    suboptions:
+      slot_id:
+        description:
+          - The GPU slot number (1-8) this profile applies to.
+        type: int
+        required: true
+      partition_profile:
+        description:
+          - The MIG partition profile name.
+          - Common profiles for H100/B200 include 1g.10gb, 2g.20gb, 3g.40gb, 4g.40gb, 7g.80gb.
+          - Use C(none) to disable MIG on this specific slot.
+        type: str
+        required: true
+      instance_count:
+        description:
+          - Number of MIG instances to create with the specified partition profile.
+          - Maximum depends on the GPU model and partition profile selected.
+        type: int
+        default: 1
+  gpu_thermal_threshold:
+    description:
+      - GPU thermal throttle threshold temperature in Celsius.
+      - When GPU temperature exceeds this threshold, performance will be throttled to prevent damage.
+      - Valid range depends on GPU model. Typical values are 80-95 for data center GPUs.
+      - Set to 0 to use the platform default.
+    type: int
+  power_capping_enabled:
+    description:
+      - Enable or disable GPU power capping.
+      - When enabled, GPU power consumption is limited to the power_cap_watts value.
+    type: bool
+    default: false
+  power_cap_watts:
+    description:
+      - Maximum power consumption per GPU in watts when power_capping_enabled is true.
+      - Valid range depends on GPU model (e.g., H100 SXM supports 300-700W).
+      - Set to 0 to use the platform default TDP.
+    type: int
+author:
+  - Steve Fulmer (@stevefulme1)
+'''
+
+EXAMPLES = r'''
+- name: Create GPU compute policy without MIG
+  cisco.intersight.intersight_gpu_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: AI-Factory
+    name: gpu-compute-default
+    description: Standard GPU compute mode for inference
+    gpu_mode: compute
+
+- name: Create GPU policy with MIG partitioning for H100
+  cisco.intersight.intersight_gpu_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: gpu-mig-inference
+    description: MIG partitioned for multi-tenant inference
+    gpu_mode: compute
+    mig_enabled: true
+    mig_profiles:
+      - slot_id: 1
+        partition_profile: 3g.40gb
+        instance_count: 2
+      - slot_id: 2
+        partition_profile: 7g.80gb
+        instance_count: 1
+
+- name: Create GPU policy with thermal and power limits
+  cisco.intersight.intersight_gpu_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: gpu-power-managed
+    description: Power-managed GPU policy for dense deployments
+    gpu_mode: compute
+    gpu_thermal_threshold: 85
+    power_capping_enabled: true
+    power_cap_watts: 400
+
+- name: Delete GPU policy
+  cisco.intersight.intersight_gpu_policy:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: gpu-compute-default
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "Name": "gpu-compute-default",
+        "ObjectType": "graphics.GpuPolicy",
+        "GpuMode": "compute",
+        "MigEnabled": false
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    mig_profile = dict(
+        slot_id=dict(type='int', required=True),
+        partition_profile=dict(type='str', required=True),
+        instance_count=dict(type='int', default=1),
+    )
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        organization=dict(type='str', default='default'),
+        name=dict(type='str', required=True),
+        description=dict(type='str', aliases=['descr']),
+        tags=dict(type='list', elements='dict'),
+        gpu_mode=dict(type='str', choices=['graphics', 'compute'], default='compute'),
+        mig_enabled=dict(type='bool', default=False),
+        mig_profiles=dict(type='list', elements='dict', options=mig_profile),
+        gpu_thermal_threshold=dict(type='int'),
+        power_capping_enabled=dict(type='bool', default=False),
+        power_cap_watts=dict(type='int'),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/graphics/GpuPolicies'
+
+    intersight.api_body = {
+        'Name': intersight.module.params['name'],
+        'Organization': {
+            'Name': intersight.module.params['organization'],
+        },
+    }
+
+    if module.params['state'] == 'present':
+        intersight.set_tags_and_description()
+
+        intersight.api_body['GpuMode'] = module.params['gpu_mode']
+        intersight.api_body['MigEnabled'] = module.params['mig_enabled']
+
+        # MIG partition profiles
+        if module.params['mig_enabled'] and module.params.get('mig_profiles'):
+            mig_configs = []
+            for profile in module.params['mig_profiles']:
+                mig_configs.append({
+                    'SlotId': profile['slot_id'],
+                    'PartitionProfile': profile['partition_profile'],
+                    'InstanceCount': profile['instance_count'],
+                })
+            intersight.api_body['MigProfiles'] = mig_configs
+
+        # Thermal threshold
+        if module.params.get('gpu_thermal_threshold') is not None:
+            intersight.api_body['GpuThermalThreshold'] = module.params['gpu_thermal_threshold']
+
+        # Power capping
+        if module.params['power_capping_enabled']:
+            intersight.api_body['PowerCappingEnabled'] = True
+            if module.params.get('power_cap_watts') is not None:
+                intersight.api_body['PowerCapWatts'] = module.params['power_cap_watts']
+        else:
+            intersight.api_body['PowerCappingEnabled'] = False
+
+    intersight.configure_policy_or_profile(resource_path=resource_path)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds three new modules to support Cisco AI Factory and Unified Edge compute infrastructure requirements from the [AI Factory Ansible Automation TRD](https://github.com/CiscoDevNet/intersight-ansible/issues):

- **`intersight_bios_ai_tuning`** — Pre-validated BIOS policy presets for AI workloads
- **`intersight_gpu_policy`** — GPU policy with MIG partitioning, thermal, and power controls
- **`intersight_confidential_compute`** — Confidential computing BIOS presets (AMD SEV/SNP, Intel SGX)

## Module Details

### 1. `intersight_bios_ai_tuning`

Creates BIOS policies using named tuning profiles that set dozens of BIOS knobs at once:

| Profile | Use Case | Key Settings |
|---------|----------|-------------|
| `gpu_inference` | H100/B200 inference servers | GPU ACS enabled, NUMA optimized, P-states disabled, SR-IOV enabled |
| `gpu_training` | Large-scale GPU training | All inference settings + max power, balanced workload config |
| `cpu_inference` | CPU-only inference | Turbo Boost, native HWPM, LLC prefetch |
| `edge_ai` | Unified Edge nodes | Energy-efficient turbo, balanced performance |

Supports `gpu_count` (1-8) for ACS control and per-knob overrides (`numa_optimized`, `cpu_power_management`, `sriov`, etc.).

### 2. `intersight_gpu_policy`

Configures GPU operating mode, MIG partitioning, and hardware limits:

- `gpu_mode`: graphics or compute
- `mig_enabled` + `mig_profiles`: per-slot MIG partition configuration (e.g., `3g.40gb`, `7g.80gb`)
- `gpu_thermal_threshold`: temperature throttle limit in Celsius
- `power_capping_enabled` + `power_cap_watts`: per-GPU power limits

### 3. `intersight_confidential_compute`

Creates BIOS policies for hardware-level AI workload isolation:

| Profile | Technology | What It Protects |
|---------|-----------|-----------------|
| `amd_sev` | AMD Secure Encrypted Virtualization | VM memory encryption with per-VM keys |
| `amd_sev_snp` | AMD SEV + Secure Nested Paging | Memory encryption + integrity (anti-tampering) |
| `intel_sgx` | Intel Software Guard Extensions | Application-level encrypted enclaves |
| `intel_sgx_with_auto_reg` | Intel SGX + auto-registration | SGX with simplified attestation enrollment |

## Design Decisions

- All three modules use the existing `configure_policy_or_profile()` pattern from `IntersightModule` for consistency with the rest of the collection
- `intersight_bios_ai_tuning` and `intersight_confidential_compute` write to `/bios/Policies` (same resource as `intersight_bios_policy`) — they are convenience wrappers that set validated combinations of knobs
- `intersight_gpu_policy` writes to `/graphics/GpuPolicies` as a distinct resource type
- All defaults preserve backward compatibility — existing playbooks are unaffected

## Test plan

- [ ] `ansible-lint` — passed (production profile)
- [ ] `pycodestyle` — passed
- [ ] `ansible-test sanity --test validate-modules` — passed
- [ ] `ansible-test sanity --test pep8` — passed
- [ ] `ansible-test sanity --test pylint` — passed
- [ ] `ansible-doc` renders correctly for all three modules
- [ ] Create BIOS policy with `tuning_profile: gpu_inference` and verify knobs are set correctly in Intersight
- [ ] Create GPU policy with MIG profiles and verify partitioning
- [ ] Create confidential compute policy with `security_profile: amd_sev` and verify SEV BIOS knobs
- [ ] Verify idempotency — re-running with same params reports no changes
- [ ] Verify `state: absent` deletes the policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)