### PR TITLE
Add stable-2.20 and stable-2.21 to CI test matrices

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -82,6 +82,8 @@ jobs:
           - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
+          - stable-2.21
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -135,6 +137,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
     outputs:
       results: ${{ steps.test-results.outputs.results }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,8 @@ jobs:
           - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
+          - stable-2.21
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -41,7 +41,6 @@ import json
 import hashlib
 from typing import Optional
 
-from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.basic import env_fallback
@@ -128,7 +127,7 @@ def compare_values(expected, actual):
     try:
         if isinstance(expected, list) and isinstance(actual, list):
             return compare_lists(expected, actual)
-        for (key, value) in iteritems(expected):
+        for (key, value) in expected.items():
             if re.search(r'P(ass)?w(or)?d', key) or re.search(r'OctetString', key) or re.search(r'IsOctetStringSet', key) or key not in actual:
                 # do not compare any password related attributes, OctetString (secrets), IsOctetStringSet, or attributes that are not in the actual resource
                 continue


### PR DESCRIPTION
#### SUMMARY
- Add ansible-core stable-2.20 and stable-2.21 to CI workflow test matrices to ensure the collection is tested against the latest supported ansible-core releases.
- stable-2.20 added to unit tests and sanity tests; stable-2.21 added to unit, integration, and sanity tests.

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
- .github/workflows/ansible-test.yml
- .github/workflows/main.yml

#### ADDITIONAL INFORMATION
- No functional code changes; CI-only update.
- Ensures continued compatibility testing as new ansible-core stable branches are released.