### PR TITLE
Add missing info modules for 4 policies

### DIFF
--- a/plugins/modules/intersight_imc_access_policy_info.py
+++ b/plugins/modules/intersight_imc_access_policy_info.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_imc_access_policy_info
+short_description: Gather information about IMC Access Policies
+description:
+  - Gathers information about IMC Access Policies on Cisco Intersight.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the IMC Access Policy.
+    type: str
+author:
+  - Steve Fulmer (@sfulmer)
+'''
+
+EXAMPLES = r'''
+- name: Get IMC Access Policy Info
+  cisco.intersight.intersight_imc_access_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "imc-access-policy"
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "imc-access-policy",
+        "ObjectType": "access.Policy",
+        "AddressType": {}
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str', default='default'),
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/access/Policies'
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(resource_path=resource_path, query_params=query_params, return_list=True)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_local_user_policy_info.py
+++ b/plugins/modules/intersight_local_user_policy_info.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_local_user_policy_info
+short_description: Gather information about Local User Policies
+description:
+  - Gathers information about Local User Policies on Cisco Intersight.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Local User Policy.
+    type: str
+author:
+  - Steve Fulmer (@sfulmer)
+'''
+
+EXAMPLES = r'''
+- name: Get Local User Policy Info
+  cisco.intersight.intersight_local_user_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "local-user-policy"
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "local-user-policy",
+        "ObjectType": "iam.EndPointUserPolicy",
+        "PasswordProperties": {}
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str', default='default'),
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/iam/EndPointUserPolicies'
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(resource_path=resource_path, query_params=query_params, return_list=True)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_ntp_policy_info.py
+++ b/plugins/modules/intersight_ntp_policy_info.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_ntp_policy_info
+short_description: Gather information about NTP Policies
+description:
+  - Gathers information about NTP Policies on Cisco Intersight.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the NTP Policy.
+    type: str
+author:
+  - Steve Fulmer (@sfulmer)
+'''
+
+EXAMPLES = r'''
+- name: Get NTP Policy Info
+  cisco.intersight.intersight_ntp_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "ntp-policy"
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "ntp-policy",
+        "ObjectType": "ntp.Policy",
+        "NtpServers": []
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str', default='default'),
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/ntp/Policies'
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(resource_path=resource_path, query_params=query_params, return_list=True)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_virtual_media_policy_info.py
+++ b/plugins/modules/intersight_virtual_media_policy_info.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_virtual_media_policy_info
+short_description: Gather information about Virtual Media Policies
+description:
+  - Gathers information about Virtual Media Policies on Cisco Intersight.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+    type: str
+    default: default
+  name:
+    description:
+      - The name assigned to the Virtual Media Policy.
+    type: str
+author:
+  - Steve Fulmer (@sfulmer)
+'''
+
+EXAMPLES = r'''
+- name: Get Virtual Media Policy Info
+  cisco.intersight.intersight_virtual_media_policy_info:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    name: "virtual-media-policy"
+'''
+
+RETURN = r'''
+api_response:
+  description: The API response output returned by the specified resource.
+  returned: always
+  type: list
+  sample:
+    [
+      {
+        "Name": "virtual-media-policy",
+        "ObjectType": "vmedia.Policy",
+        "Mappings": []
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str', default='default'),
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    resource_path = '/vmedia/Policies'
+    query_params = intersight.set_query_params()
+
+    intersight.get_resource(resource_path=resource_path, query_params=query_params, return_list=True)
+
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/intersight_imc_access_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_imc_access_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_imc_access_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_imc_access_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_imc_access_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_imc_access_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml

--- a/tests/integration/targets/intersight_imc_access_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_imc_access_policy/tasks/tests.yml
@@ -1,0 +1,95 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_imc_access_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_imc_access_basic
+      - test_imc_access_updated
+
+  - name: Create basic IMC Access policy
+    cisco.intersight.intersight_imc_access_policy:
+      <<: *api_info
+      name: test_imc_access_basic
+      description: "Test IMC access policy"
+      vlan_id: 100
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation
+
+  - name: Verify basic IMC Access policy creation
+    ansible.builtin.assert:
+      that:
+        - basic_creation.changed
+
+  - name: Create basic IMC Access policy (idempotency check)
+    cisco.intersight.intersight_imc_access_policy:
+      <<: *api_info
+      name: test_imc_access_basic
+      description: "Test IMC access policy"
+      vlan_id: 100
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation_ide
+
+  - name: Verify basic IMC Access policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not basic_creation_ide.changed
+
+  # -- Info module tests --
+  - name: Get IMC Access policy info by name
+    cisco.intersight.intersight_imc_access_policy_info:
+      <<: *api_info
+      name: test_imc_access_basic
+    register: imc_info_by_name
+
+  - name: Verify IMC Access policy info by name
+    ansible.builtin.assert:
+      that:
+        - imc_info_by_name.api_response | length == 1
+        - imc_info_by_name.api_response[0].Name == "test_imc_access_basic"
+
+  - name: Get all IMC Access policies info
+    cisco.intersight.intersight_imc_access_policy_info:
+      <<: *api_info
+    register: imc_info_all
+
+  - name: Verify all IMC Access policies info returns results
+    ansible.builtin.assert:
+      that:
+        - imc_info_all.api_response | length >= 1
+
+  - name: Get IMC Access policy info for nonexistent policy
+    cisco.intersight.intersight_imc_access_policy_info:
+      <<: *api_info
+      name: nonexistent_imc_access_12345
+    register: imc_info_missing
+
+  - name: Verify nonexistent IMC Access policy returns empty
+    ansible.builtin.assert:
+      that:
+        - imc_info_missing.api_response | length == 0
+
+  always:
+  - name: Remove all test IMC Access policies
+    cisco.intersight.intersight_imc_access_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_imc_access_basic
+      - test_imc_access_updated

--- a/tests/integration/targets/intersight_local_user_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_local_user_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_local_user_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_local_user_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_local_user_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_local_user_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml

--- a/tests/integration/targets/intersight_local_user_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_local_user_policy/tasks/tests.yml
@@ -1,0 +1,101 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_local_user_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_local_user_basic
+      - test_local_user_updated
+
+  - name: Create basic Local User policy
+    cisco.intersight.intersight_local_user_policy:
+      <<: *api_info
+      name: test_local_user_basic
+      description: "Test local user policy"
+      local_users:
+        - username: testadmin
+          role: admin
+          password: "{{ test_password | default('Ch@ngeMe123!') }}"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation
+
+  - name: Verify basic Local User policy creation
+    ansible.builtin.assert:
+      that:
+        - basic_creation.changed
+
+  - name: Create basic Local User policy (idempotency check)
+    cisco.intersight.intersight_local_user_policy:
+      <<: *api_info
+      name: test_local_user_basic
+      description: "Test local user policy"
+      local_users:
+        - username: testadmin
+          role: admin
+          password: "{{ test_password | default('Ch@ngeMe123!') }}"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation_ide
+
+  - name: Verify basic Local User policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not basic_creation_ide.changed
+
+  # -- Info module tests --
+  - name: Get Local User policy info by name
+    cisco.intersight.intersight_local_user_policy_info:
+      <<: *api_info
+      name: test_local_user_basic
+    register: user_info_by_name
+
+  - name: Verify Local User policy info by name
+    ansible.builtin.assert:
+      that:
+        - user_info_by_name.api_response | length == 1
+        - user_info_by_name.api_response[0].Name == "test_local_user_basic"
+
+  - name: Get all Local User policies info
+    cisco.intersight.intersight_local_user_policy_info:
+      <<: *api_info
+    register: user_info_all
+
+  - name: Verify all Local User policies info returns results
+    ansible.builtin.assert:
+      that:
+        - user_info_all.api_response | length >= 1
+
+  - name: Get Local User policy info for nonexistent policy
+    cisco.intersight.intersight_local_user_policy_info:
+      <<: *api_info
+      name: nonexistent_local_user_12345
+    register: user_info_missing
+
+  - name: Verify nonexistent Local User policy returns empty
+    ansible.builtin.assert:
+      that:
+        - user_info_missing.api_response | length == 0
+
+  always:
+  - name: Remove all test Local User policies
+    cisco.intersight.intersight_local_user_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_local_user_basic
+      - test_local_user_updated

--- a/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
@@ -214,6 +214,40 @@
       that:
         - disabled_update.changed
 
+  # -- Info module tests --
+  - name: Get NTP policy info by name
+    cisco.intersight.intersight_ntp_policy_info:
+      <<: *api_info
+      name: test_ntp_policy_basic
+    register: ntp_info_by_name
+
+  - name: Verify NTP policy info by name
+    ansible.builtin.assert:
+      that:
+        - ntp_info_by_name.api_response | length == 1
+        - ntp_info_by_name.api_response[0].Name == "test_ntp_policy_basic"
+
+  - name: Get all NTP policies info
+    cisco.intersight.intersight_ntp_policy_info:
+      <<: *api_info
+    register: ntp_info_all
+
+  - name: Verify all NTP policies info returns results
+    ansible.builtin.assert:
+      that:
+        - ntp_info_all.api_response | length >= 1
+
+  - name: Get NTP policy info for nonexistent policy
+    cisco.intersight.intersight_ntp_policy_info:
+      <<: *api_info
+      name: nonexistent_ntp_policy_12345
+    register: ntp_info_missing
+
+  - name: Verify nonexistent NTP policy returns empty
+    ansible.builtin.assert:
+      that:
+        - ntp_info_missing.api_response | length == 0
+
   always:
   - name: Remove all test NTP policies
     cisco.intersight.intersight_ntp_policy:

--- a/tests/integration/targets/intersight_virtual_media_policy/defaults/main.yml
+++ b/tests/integration/targets/intersight_virtual_media_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_virtual_media_policy/meta/main.yml
+++ b/tests/integration/targets/intersight_virtual_media_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_virtual_media_policy/tasks/main.yml
+++ b/tests/integration/targets/intersight_virtual_media_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- block:
+  - name: Run tests
+    include_tasks: tests.yml

--- a/tests/integration/targets/intersight_virtual_media_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_virtual_media_policy/tasks/tests.yml
@@ -1,0 +1,93 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  - name: Make sure Env is clean
+    cisco.intersight.intersight_virtual_media_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_vmedia_basic
+      - test_vmedia_updated
+
+  - name: Create basic Virtual Media policy
+    cisco.intersight.intersight_virtual_media_policy:
+      <<: *api_info
+      name: test_vmedia_basic
+      description: "Test virtual media policy"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation
+
+  - name: Verify basic Virtual Media policy creation
+    ansible.builtin.assert:
+      that:
+        - basic_creation.changed
+
+  - name: Create basic Virtual Media policy (idempotency check)
+    cisco.intersight.intersight_virtual_media_policy:
+      <<: *api_info
+      name: test_vmedia_basic
+      description: "Test virtual media policy"
+      tags:
+        - Key: Site
+          Value: Test
+    register: basic_creation_ide
+
+  - name: Verify basic Virtual Media policy creation (idempotency check)
+    ansible.builtin.assert:
+      that:
+        - not basic_creation_ide.changed
+
+  # -- Info module tests --
+  - name: Get Virtual Media policy info by name
+    cisco.intersight.intersight_virtual_media_policy_info:
+      <<: *api_info
+      name: test_vmedia_basic
+    register: vmedia_info_by_name
+
+  - name: Verify Virtual Media policy info by name
+    ansible.builtin.assert:
+      that:
+        - vmedia_info_by_name.api_response | length == 1
+        - vmedia_info_by_name.api_response[0].Name == "test_vmedia_basic"
+
+  - name: Get all Virtual Media policies info
+    cisco.intersight.intersight_virtual_media_policy_info:
+      <<: *api_info
+    register: vmedia_info_all
+
+  - name: Verify all Virtual Media policies info returns results
+    ansible.builtin.assert:
+      that:
+        - vmedia_info_all.api_response | length >= 1
+
+  - name: Get Virtual Media policy info for nonexistent policy
+    cisco.intersight.intersight_virtual_media_policy_info:
+      <<: *api_info
+      name: nonexistent_vmedia_12345
+    register: vmedia_info_missing
+
+  - name: Verify nonexistent Virtual Media policy returns empty
+    ansible.builtin.assert:
+      that:
+        - vmedia_info_missing.api_response | length == 0
+
+  always:
+  - name: Remove all test Virtual Media policies
+    cisco.intersight.intersight_virtual_media_policy:
+      <<: *api_info
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - test_vmedia_basic
+      - test_vmedia_updated


### PR DESCRIPTION
## Summary
- Adds `intersight_ntp_policy_info` module (queries `/ntp/Policies`)
- Adds `intersight_imc_access_policy_info` module (queries `/access/Policies`)
- Adds `intersight_local_user_policy_info` module (queries `/iam/EndPointUserPolicies`)
- Adds `intersight_virtual_media_policy_info` module (queries `/vmedia/Policies`)
- All follow the existing `_info` module pattern (e.g., `intersight_adapter_config_policy_info`)

## Test plan
- [x] Python syntax validation passes
- [x] `ansible-test sanity --test validate-modules` passes
- [x] `ansible-lint` passes (production profile)
- [ ] Integration test with Intersight sandbox

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)