### PR TITLE
fix(ci): match pull_request_target event in change detection script

### DIFF
--- a/.github/workflows/scripts/map_changes_to_tests.py
+++ b/.github/workflows/scripts/map_changes_to_tests.py
@@ -12,7 +12,8 @@ def get_changed_files():
     """Get list of changed files in the current PR/commit."""
     try:
         # For PR context, compare against the base branch
-        if os.getenv('GITHUB_EVENT_NAME') == 'pull_request':
+        event_name = os.getenv('GITHUB_EVENT_NAME', '')
+        if event_name in ('pull_request', 'pull_request_target'):
             base_ref = os.getenv('GITHUB_BASE_REF', 'main')
             result = subprocess.run(
                 ['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],


### PR DESCRIPTION
#### SUMMARY
- Fix integration test skip logic in `map_changes_to_tests.py` to correctly detect all changed files in a PR
- The workflow uses `pull_request_target` but the script only checked for `pull_request`, causing it to compare `HEAD~1` (last commit only) instead of the full PR diff against the base branch
- When a follow-up commit touched only non-relevant files, integration tests were incorrectly skipped even though earlier commits in the PR modified modules or tests

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- .github/workflows/scripts/map_changes_to_tests.py

#### ADDITIONAL INFORMATION
- One-line fix: added `pull_request_target` to the event name check so `git diff origin/{base_ref}...HEAD` is used for both PR trigger types
- No backward compatibility concerns