### PR TITLE
fix: allow state=absent without create-only params in modules and tests

### DIFF
--- a/plugins/modules/intersight_ai_storage_policy.py
+++ b/plugins/modules/intersight_ai_storage_policy.py
@@ -285,7 +285,6 @@ def main():
         storage_profile=dict(
             type='str',
             choices=['inference_optimized', 'training_data', 'model_cache', 'edge_compact'],
-            required=True,
         ),
         nvme_slots=dict(type='str'),
         nvme_mode=dict(type='str', choices=['direct', 'controller']),
@@ -314,6 +313,9 @@ def main():
     }
 
     if module.params['state'] == 'present':
+        if not module.params.get('storage_profile'):
+            module.fail_json(msg="storage_profile is required when state is 'present'")
+
         intersight.set_tags_and_description()
 
         # Deep copy profile settings

--- a/plugins/modules/intersight_ai_storage_policy.py
+++ b/plugins/modules/intersight_ai_storage_policy.py
@@ -70,7 +70,6 @@ options:
         constrained storage capacity.
     type: str
     choices: [inference_optimized, training_data, model_cache, edge_compact]
-    required: true
   nvme_slots:
     description:
       - NVMe drive slots to configure in the selected mode.

--- a/plugins/modules/intersight_bios_ai_tuning.py
+++ b/plugins/modules/intersight_bios_ai_tuning.py
@@ -279,7 +279,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
-        tuning_profile=dict(type='str', choices=['gpu_inference', 'gpu_training', 'cpu_inference', 'edge_ai'], required=True),
+        tuning_profile=dict(type='str', choices=['gpu_inference', 'gpu_training', 'cpu_inference', 'edge_ai']),
         gpu_count=dict(type='int', default=8),
         numa_optimized=dict(type='str', choices=['platform-default', 'enabled', 'disabled']),
         cpu_power_management=dict(type='str', choices=['platform-default', 'performance', 'energy-efficient', 'custom']),
@@ -311,6 +311,9 @@ def main():
     }
 
     if module.params['state'] == 'present':
+        if not module.params.get('tuning_profile'):
+            module.fail_json(msg="tuning_profile is required when state is 'present'")
+
         intersight.set_tags_and_description()
 
         # Apply tuning profile preset

--- a/plugins/modules/intersight_bios_ai_tuning.py
+++ b/plugins/modules/intersight_bios_ai_tuning.py
@@ -69,7 +69,6 @@ options:
         and NUMA optimization suitable for edge deployment constraints.
     type: str
     choices: [gpu_inference, gpu_training, cpu_inference, edge_ai]
-    required: true
   gpu_count:
     description:
       - Number of GPUs to enable via ACS Control (1-8).

--- a/plugins/modules/intersight_confidential_compute.py
+++ b/plugins/modules/intersight_confidential_compute.py
@@ -70,7 +70,6 @@ options:
         simplified attestation service enrollment.
     type: str
     choices: [amd_sev, amd_sev_snp, intel_sgx, intel_sgx_with_auto_reg]
-    required: true
   sev_asid_count:
     description:
       - Number of AMD SEV Address Space Identifiers (ASIDs) to allocate.

--- a/plugins/modules/intersight_confidential_compute.py
+++ b/plugins/modules/intersight_confidential_compute.py
@@ -221,7 +221,6 @@ def main():
         security_profile=dict(
             type='str',
             choices=['amd_sev', 'amd_sev_snp', 'intel_sgx', 'intel_sgx_with_auto_reg'],
-            required=True,
         ),
         sev_asid_count=dict(type='str', choices=['platform-default', '253 ASIDs', '509 ASIDs']),
         sgx_epoch0=dict(type='str'),
@@ -249,6 +248,9 @@ def main():
     }
 
     if module.params['state'] == 'present':
+        if not module.params.get('security_profile'):
+            module.fail_json(msg="security_profile is required when state is 'present'")
+
         intersight.set_tags_and_description()
 
         # Apply security profile preset

--- a/plugins/modules/intersight_imc_access_policy.py
+++ b/plugins/modules/intersight_imc_access_policy.py
@@ -64,6 +64,7 @@ options:
   ip_pool:
     description:
       - IP Pool used to assign IP address and other required network settings.
+      - Required when C(state=present).
       - May be provided as a string pool name in the same organization as the policy.
       - May also be provided as a dictionary with C(name) and optional C(organization).
       - Dictionary field C(name) is the name of the IP Pool used to assign IP address and other required network settings.
@@ -71,7 +72,6 @@ options:
       - Dictionary field C(organization) defaults to the value of C(organization) when omitted.
       - Set dictionary field C(organization) when the IMC Access Policy should consume an IP Pool from a different Organization.
     type: raw
-    required: true
 author:
   - David Soper (@dsoper2)
 '''
@@ -178,20 +178,15 @@ def main():
         tags=dict(type='list', elements='dict'),
         out_of_band=dict(type='bool', default=False),
         vlan_id=dict(type='int'),
-        ip_pool=dict(type='raw', required=True),
+        ip_pool=dict(type='raw'),
     )
 
     module = AnsibleModule(
         argument_spec,
-        required_if=[
-            ('out_of_band', False, ['vlan_id']),
-        ],
         supports_check_mode=True,
     )
 
     intersight = IntersightModule(module)
-    ip_pool = normalize_ip_pool(module, module.params['ip_pool'], module.params['organization'])
-    ip_pool_organization = ip_pool['organization']
 
     organization_moid = intersight.get_moid_by_name(
         resource_path='/organization/Organizations',
@@ -200,49 +195,58 @@ def main():
     if not organization_moid:
         module.fail_json(msg=f"Organization '{module.params['organization']}' not found")
 
-    ip_pool_moid = intersight.get_moid_by_name_and_org(
-        resource_path='/ippool/Pools',
-        resource_name=ip_pool['name'],
-        organization_name=ip_pool_organization,
-    )
-    if not ip_pool_moid:
-        module.fail_json(
-            msg=f"IP pool '{ip_pool['name']}' not found in organization '{ip_pool_organization}'"
-        )
-
     intersight.result['api_response'] = {}
     intersight.result['trace_id'] = ''
     intersight.api_body = {
         'Name': intersight.module.params['name'],
-
         'Organization': {
             'Name': intersight.module.params['organization'],
         },
     }
+
+    ip_pool_moid = None
     if module.params['state'] == 'present':
+        if not module.params.get('ip_pool'):
+            module.fail_json(msg="ip_pool is required when state is 'present'")
+        if not module.params['out_of_band'] and module.params.get('vlan_id') is None:
+            module.fail_json(msg="vlan_id is required when out_of_band is false and state is 'present'")
+
+        ip_pool = normalize_ip_pool(module, module.params['ip_pool'], module.params['organization'])
+        ip_pool_organization = ip_pool['organization']
+
+        ip_pool_moid = intersight.get_moid_by_name_and_org(
+            resource_path='/ippool/Pools',
+            resource_name=ip_pool['name'],
+            organization_name=ip_pool_organization,
+        )
+        if not ip_pool_moid:
+            module.fail_json(
+                msg=f"IP pool '{ip_pool['name']}' not found in organization '{ip_pool_organization}'"
+            )
+
         intersight.set_tags_and_description()
 
-    if intersight.module.params['out_of_band']:
-        intersight.api_body['ConfigurationType'] = {
-            'ObjectType': 'access.ConfigurationType',
-            'ConfigureInband': False,
-            'ConfigureOutOfBand': True,
-        }
-        intersight.api_body['OutOfBandIpPool'] = {
-            'ObjectType': 'ippool.Pool',
-            'Moid': ip_pool_moid,
-        }
-    else:
-        intersight.api_body['InbandVlan'] = intersight.module.params['vlan_id']
-        intersight.api_body['ConfigurationType'] = {
-            'ObjectType': 'access.ConfigurationType',
-            'ConfigureInband': True,
-            'ConfigureOutOfBand': False,
-        }
-        intersight.api_body['InbandIpPool'] = {
-            'ObjectType': 'ippool.Pool',
-            'Moid': ip_pool_moid,
-        }
+        if intersight.module.params['out_of_band']:
+            intersight.api_body['ConfigurationType'] = {
+                'ObjectType': 'access.ConfigurationType',
+                'ConfigureInband': False,
+                'ConfigureOutOfBand': True,
+            }
+            intersight.api_body['OutOfBandIpPool'] = {
+                'ObjectType': 'ippool.Pool',
+                'Moid': ip_pool_moid,
+            }
+        else:
+            intersight.api_body['InbandVlan'] = intersight.module.params['vlan_id']
+            intersight.api_body['ConfigurationType'] = {
+                'ObjectType': 'access.ConfigurationType',
+                'ConfigureInband': True,
+                'ConfigureOutOfBand': False,
+            }
+            intersight.api_body['InbandIpPool'] = {
+                'ObjectType': 'ippool.Pool',
+                'Moid': ip_pool_moid,
+            }
 
     # get the current state of the resource
     filter_str = "Name eq '" + intersight.module.params['name'] + "'"

--- a/plugins/modules/intersight_unified_edge_profile.py
+++ b/plugins/modules/intersight_unified_edge_profile.py
@@ -69,7 +69,6 @@ options:
         for demanding edge AI inference and light training workloads.
     type: str
     choices: [xe9305, xe130c_m8, xe150c_m8]
-    required: true
   bios_policy:
     description:
       - Name of BIOS Policy to associate with this template.

--- a/plugins/modules/intersight_unified_edge_profile.py
+++ b/plugins/modules/intersight_unified_edge_profile.py
@@ -266,7 +266,7 @@ def main():
         name=dict(type='str', required=True),
         description=dict(type='str', aliases=['descr']),
         tags=dict(type='list', elements='dict'),
-        hardware_platform=dict(type='str', choices=['xe9305', 'xe130c_m8', 'xe150c_m8'], required=True),
+        hardware_platform=dict(type='str', choices=['xe9305', 'xe130c_m8', 'xe150c_m8']),
         bios_policy=dict(type='str'),
         boot_order_policy=dict(type='str'),
         firmware_policy=dict(type='str'),
@@ -303,6 +303,9 @@ def main():
     }
 
     if module.params['state'] == 'present':
+        if not module.params.get('hardware_platform'):
+            module.fail_json(msg="hardware_platform is required when state is 'present'")
+
         intersight.set_tags_and_description()
 
         # Always set target platform to Unified Edge

--- a/tests/integration/targets/intersight_imc_access_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_imc_access_policy/tasks/tests.yml
@@ -18,12 +18,33 @@
       - test_imc_access_basic
       - test_imc_access_updated
 
+  - name: Remove prerequisite IP pool if leftover
+    cisco.intersight.intersight_ip_pool:
+      <<: *api_info
+      name: test_imc_access_ip_pool
+      state: absent
+
+  - name: Create prerequisite IP pool for IMC Access tests
+    cisco.intersight.intersight_ip_pool:
+      <<: *api_info
+      name: test_imc_access_ip_pool
+      description: "IP pool for IMC access policy tests"
+      ipv4_config:
+        netmask: "255.255.255.0"
+        gateway: "172.17.200.1"
+        primary_dns: "172.17.200.2"
+        secondary_dns: ""
+      ipv4_blocks:
+        - from: "172.17.200.10"
+          size: 8
+
   - name: Create basic IMC Access policy
     cisco.intersight.intersight_imc_access_policy:
       <<: *api_info
       name: test_imc_access_basic
       description: "Test IMC access policy"
       vlan_id: 100
+      ip_pool: test_imc_access_ip_pool
       tags:
         - Key: Site
           Value: Test
@@ -40,6 +61,7 @@
       name: test_imc_access_basic
       description: "Test IMC access policy"
       vlan_id: 100
+      ip_pool: test_imc_access_ip_pool
       tags:
         - Key: Site
           Value: Test
@@ -82,7 +104,7 @@
   - name: Verify nonexistent IMC Access policy returns empty
     ansible.builtin.assert:
       that:
-        - imc_info_missing.api_response | length == 0
+        - imc_info_missing.count == 0
 
   always:
   - name: Remove all test IMC Access policies
@@ -93,3 +115,9 @@
     loop:
       - test_imc_access_basic
       - test_imc_access_updated
+
+  - name: Remove prerequisite IP pool
+    cisco.intersight.intersight_ip_pool:
+      <<: *api_info
+      name: test_imc_access_ip_pool
+      state: absent

--- a/tests/integration/targets/intersight_local_user_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_local_user_policy/tasks/tests.yml
@@ -88,7 +88,7 @@
   - name: Verify nonexistent Local User policy returns empty
     ansible.builtin.assert:
       that:
-        - user_info_missing.api_response | length == 0
+        - user_info_missing.count == 0
 
   always:
   - name: Remove all test Local User policies

--- a/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
@@ -246,7 +246,7 @@
   - name: Verify nonexistent NTP policy returns empty
     ansible.builtin.assert:
       that:
-        - ntp_info_missing.api_response | length == 0
+        - ntp_info_missing.count == 0
 
   always:
   - name: Remove all test NTP policies

--- a/tests/integration/targets/intersight_rest_api/tasks/main.yml
+++ b/tests/integration/targets/intersight_rest_api/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Run tests
-  include_tasks: tests.yml 
+  import_tasks: tests.yml

--- a/tests/integration/targets/intersight_rest_api/tasks/tests.yml
+++ b/tests/integration/targets/intersight_rest_api/tasks/tests.yml
@@ -8,7 +8,6 @@
         api_uri: "{{ api_uri | default(omit) }}"
         validate_certs: "{{ validate_certs | default(omit) }}"
 
-  
   # Fetch Organization MOID
   - name: Get organization details using REST API
     cisco.intersight.intersight_rest_api:

--- a/tests/integration/targets/intersight_virtual_media_policy/tasks/tests.yml
+++ b/tests/integration/targets/intersight_virtual_media_policy/tasks/tests.yml
@@ -80,7 +80,7 @@
   - name: Verify nonexistent Virtual Media policy returns empty
     ansible.builtin.assert:
       that:
-        - vmedia_info_missing.api_response | length == 0
+        - vmedia_info_missing.count == 0
 
   always:
   - name: Remove all test Virtual Media policies


### PR DESCRIPTION
#### SUMMARY
- Remove `required=True` from module params that are only needed for `state=present` (ip_pool, storage_profile, tuning_profile, security_profile, hardware_platform) so `state=absent` works with just the resource name
- Fix integration tests: add ip_pool prerequisite for imc_access_policy, use `count` for empty result assertions, switch rest_api to `import_tasks` for role defaults

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- plugins/modules/intersight_imc_access_policy.py
- plugins/modules/intersight_ai_storage_policy.py
- plugins/modules/intersight_bios_ai_tuning.py
- plugins/modules/intersight_confidential_compute.py
- plugins/modules/intersight_unified_edge_profile.py
- tests/integration/targets/intersight_imc_access_policy/tasks/tests.yml
- tests/integration/targets/intersight_local_user_policy/tasks/tests.yml
- tests/integration/targets/intersight_ntp_policy/tasks/tests.yml
- tests/integration/targets/intersight_virtual_media_policy/tasks/tests.yml
- tests/integration/targets/intersight_rest_api/tasks/main.yml
- tests/integration/targets/intersight_rest_api/tasks/tests.yml

#### ADDITIONAL INFORMATION
- Modules still validate required params at runtime when `state=present`
- No breaking changes to existing playbooks