### PR TITLE
feat: add OAuth2 bearer token authentication support

### DIFF
--- a/plugins/doc_fragments/intersight.py
+++ b/plugins/doc_fragments/intersight.py
@@ -25,8 +25,8 @@ options:
     - "    <your private key data>"
     - "    -----END EC PRIVATE KEY-----'"
     - If not set, the value of the INTERSIGHT_API_PRIVATE_KEY environment variable is used.
+    - Required if I(api_bearer_token) is not provided.
     type: path
-    required: yes
   api_uri:
     description:
     - URI used to access the Intersight API.
@@ -37,8 +37,14 @@ options:
     description:
     - Public API Key ID associated with the private key.
     - If not set, the value of the INTERSIGHT_API_KEY_ID environment variable is used.
+    - Required if I(api_bearer_token) is not provided.
     type: str
-    required: yes
+  api_bearer_token:
+    description:
+    - Bearer token for OAuth2 authentication with the Intersight API.
+    - When provided, I(api_key_id) and I(api_private_key) are not required and the C(cryptography) Python library is not needed.
+    - If not set, the value of the INTERSIGHT_API_BEARER_TOKEN environment variable is used.
+    type: str
   validate_certs:
     description:
     - Boolean control for verifying the api_uri TLS certificate

--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -55,10 +55,10 @@ except ImportError:
     HAS_CRYPTOGRAPHY = False
 
 intersight_argument_spec = dict(
-    api_private_key=dict(fallback=(env_fallback, ['INTERSIGHT_API_PRIVATE_KEY']), type='path', required=True,
-                         no_log=True),
+    api_private_key=dict(fallback=(env_fallback, ['INTERSIGHT_API_PRIVATE_KEY']), type='path', no_log=True),
     api_uri=dict(fallback=(env_fallback, ['INTERSIGHT_API_URI']), type='str', default='https://intersight.com/api/v1'),
-    api_key_id=dict(fallback=(env_fallback, ['INTERSIGHT_API_KEY_ID']), type='str', required=True),
+    api_key_id=dict(fallback=(env_fallback, ['INTERSIGHT_API_KEY_ID']), type='str'),
+    api_bearer_token=dict(fallback=(env_fallback, ['INTERSIGHT_API_BEARER_TOKEN']), type='str', no_log=True),
     validate_certs=dict(type='bool', default=True),
     use_proxy=dict(type='bool', default=True),
 )
@@ -177,18 +177,32 @@ class IntersightModule():
     def __init__(self, module):
         self.module = module
         self.result = dict(changed=False)
-        if not HAS_CRYPTOGRAPHY:
-            self.module.fail_json(msg='cryptography is required for this module')
         self.host = self.module.params['api_uri']
-        self.public_key = self.module.params['api_key_id']
-        try:
-            with open(self.module.params['api_private_key'], 'r') as f:
-                self.private_key = f.read()
-        except (FileNotFoundError, OSError):
-            self.private_key = self.module.params['api_private_key']
+        self.bearer_token = self.module.params.get('api_bearer_token')
         self.digest_algorithm = ''
         self.response_list = []
         self.update_method = ''
+
+        if self.bearer_token:
+            self.public_key = None
+            self.private_key = None
+        else:
+            if not self.module.params.get('api_key_id'):
+                self.module.fail_json(
+                    msg='api_key_id is required when api_bearer_token is not provided'
+                )
+            if not self.module.params.get('api_private_key'):
+                self.module.fail_json(
+                    msg='api_private_key is required when api_bearer_token is not provided'
+                )
+            if not HAS_CRYPTOGRAPHY:
+                self.module.fail_json(msg='cryptography is required for this module')
+            self.public_key = self.module.params['api_key_id']
+            try:
+                with open(self.module.params['api_private_key'], 'r') as f:
+                    self.private_key = f.read()
+            except (FileNotFoundError, OSError):
+                self.private_key = self.module.params['api_private_key']
 
     def get_sig_b64encode(self, data):
         """
@@ -324,34 +338,43 @@ class IntersightModule():
         # Get the current GMT Date/Time
         cdate = get_gmt_date()
 
-        # Generate the body digest
-        body_digest = get_sha256_digest(bodyString)
-        b64_body_digest = b64encode(body_digest.digest())
-
-        # Generate the authorization header
-        auth_header = {
-            'Host': target_host,
-            'Date': cdate,
-            'Digest': "SHA-256=" + b64_body_digest.decode('ascii'),
-        }
-
-        string_to_sign = prepare_str_to_sign(request_target, auth_header)
-        b64_signed_msg = self.get_sig_b64encode(string_to_sign)
-        auth_header = self.get_auth_header(auth_header, b64_signed_msg)
-
-        # Generate the HTTP requests header
         if self.update_method == 'json-patch':
             content_type = 'application/json-patch+json'
         else:
             content_type = 'application/json'
-        request_header = {
-            'Accept': 'application/json',
-            'Content-Type': content_type,
-            'Host': '{0}'.format(target_host),
-            'Date': '{0}'.format(cdate),
-            'Digest': 'SHA-256={0}'.format(b64_body_digest.decode('ascii')),
-            'Authorization': '{0}'.format(auth_header),
-        }
+
+        if self.bearer_token:
+            request_header = {
+                'Accept': 'application/json',
+                'Content-Type': content_type,
+                'Host': '{0}'.format(target_host),
+                'Date': '{0}'.format(cdate),
+                'Authorization': 'Bearer {0}'.format(self.bearer_token),
+            }
+        else:
+            # Generate the body digest
+            body_digest = get_sha256_digest(bodyString)
+            b64_body_digest = b64encode(body_digest.digest())
+
+            # Generate the authorization header
+            auth_header = {
+                'Host': target_host,
+                'Date': cdate,
+                'Digest': "SHA-256=" + b64_body_digest.decode('ascii'),
+            }
+
+            string_to_sign = prepare_str_to_sign(request_target, auth_header)
+            b64_signed_msg = self.get_sig_b64encode(string_to_sign)
+            auth_header = self.get_auth_header(auth_header, b64_signed_msg)
+
+            request_header = {
+                'Accept': 'application/json',
+                'Content-Type': content_type,
+                'Host': '{0}'.format(target_host),
+                'Date': '{0}'.format(cdate),
+                'Digest': 'SHA-256={0}'.format(b64_body_digest.decode('ascii')),
+                'Authorization': '{0}'.format(auth_header),
+            }
 
         response, info = fetch_url(self.module, target_url, data=bodyString, headers=request_header, method=method,
                                    use_proxy=self.module.params['use_proxy'])

--- a/tests/unit/test_bearer_token_auth.py
+++ b/tests/unit/test_bearer_token_auth.py
@@ -1,0 +1,101 @@
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import (
+    IntersightModule
+)
+import unittest
+from types import SimpleNamespace
+
+v3_secret_key = """
+-----BEGIN EC PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgFpLumf8DcLaJSAM1
+pp6rmKCz00eZAewOElJKETFiW/WhRANCAAT0RlNvtEUFP2n6Aq38dnWvsT1AkZjm
+B9I2RZyK1NILUMKp1rdSI05SaOS5Ca5YyJ4ZVOfSIN0ZduOSAkWaAPy0
+-----END EC PRIVATE KEY-----
+"""
+v3_key_id = "59c84e4a16267c0001c23428/59cc595416267c0001a0dfc7/62b39fc27564612d319801ce"
+
+
+class TestBearerTokenAuth(unittest.TestCase):
+
+    def test_bearer_token_skips_key_loading(self):
+        am = SimpleNamespace(params={
+            "api_key_id": None,
+            "api_private_key": None,
+            "api_bearer_token": "test-bearer-token-value",
+            "api_uri": "https://intersight.com/api/v1",
+            "validate_certs": True,
+            "use_proxy": True,
+        })
+        i = IntersightModule(am)
+        assert i.bearer_token == "test-bearer-token-value"
+        assert i.public_key is None
+        assert i.private_key is None
+
+    def test_bearer_token_no_cryptography_required(self):
+        am = SimpleNamespace(params={
+            "api_key_id": None,
+            "api_private_key": None,
+            "api_bearer_token": "my-token",
+            "api_uri": "https://intersight.com/api/v1",
+            "validate_certs": True,
+            "use_proxy": True,
+        })
+        i = IntersightModule(am)
+        assert i.bearer_token == "my-token"
+
+    def test_missing_all_auth_fails(self):
+        failed = {}
+
+        def mock_fail_json(msg):
+            failed['msg'] = msg
+            raise SystemExit(1)
+
+        am = SimpleNamespace(params={
+            "api_key_id": None,
+            "api_private_key": None,
+            "api_bearer_token": None,
+            "api_uri": "https://intersight.com/api/v1",
+            "validate_certs": True,
+            "use_proxy": True,
+        })
+        am.fail_json = mock_fail_json
+
+        with self.assertRaises(SystemExit):
+            IntersightModule(am)
+        assert 'api_key_id is required' in failed['msg']
+
+    def test_missing_private_key_fails(self):
+        failed = {}
+
+        def mock_fail_json(msg):
+            failed['msg'] = msg
+            raise SystemExit(1)
+
+        am = SimpleNamespace(params={
+            "api_key_id": "some-key-id",
+            "api_private_key": None,
+            "api_bearer_token": None,
+            "api_uri": "https://intersight.com/api/v1",
+            "validate_certs": True,
+            "use_proxy": True,
+        })
+        am.fail_json = mock_fail_json
+
+        with self.assertRaises(SystemExit):
+            IntersightModule(am)
+        assert 'api_private_key is required' in failed['msg']
+
+    def test_signature_auth_still_works_with_bearer_none(self):
+        am = SimpleNamespace(params={
+            "api_key_id": v3_key_id,
+            "api_private_key": v3_secret_key,
+            "api_bearer_token": None,
+            "api_uri": "https://intersight.com/api/v1",
+            "validate_certs": True,
+            "use_proxy": True,
+        })
+        i = IntersightModule(am)
+        assert i.bearer_token is None
+        assert i.public_key == v3_key_id
+        assert i.private_key == v3_secret_key
+        sig = i.get_sig_b64encode('')
+        assert sig is not None

--- a/tests/unit/test_v3_api_keys.py
+++ b/tests/unit/test_v3_api_keys.py
@@ -58,6 +58,7 @@ class TestIntersightModuleUtilKeyHandling(unittest.TestCase):
         am = SimpleNamespace(params={
             "api_key_id": key_id,
             "api_private_key": secret_key,
+            "api_bearer_token": None,
             "api_uri": "https://intersight.com",
         })
         i = IntersightModule(am)
@@ -96,8 +97,23 @@ class TestIntersightModuleUtilKeyHandling(unittest.TestCase):
         assert sig == expected_sig
 
     def test_with_broken_key(self):
-        with self.assertRaises(ValueError):
-            self.with_key(v2_key_id, "")
+        failed = {}
+
+        def mock_fail_json(msg):
+            failed['msg'] = msg
+            raise SystemExit(1)
+
+        am = SimpleNamespace(params={
+            "api_key_id": v2_key_id,
+            "api_private_key": "",
+            "api_bearer_token": None,
+            "api_uri": "https://intersight.com",
+        })
+        am.fail_json = mock_fail_json
+
+        with self.assertRaises(SystemExit):
+            IntersightModule(am)
+        assert 'api_private_key is required' in failed['msg']
 
     def test_with_invalid_key_type(self):
         with self.assertRaises(Exception) as cm:


### PR DESCRIPTION
## Summary

Add `api_bearer_token` as an alternative authentication method alongside existing API key pair authentication. When a bearer token is provided, modules use `Authorization: Bearer <token>` instead of HTTP Signature auth, and the `cryptography` Python library is not required.

## Motivation

This enables OAuth2/OIDC workload identity flows where automation platforms (e.g., Ansible Automation Platform) issue short-lived JWT tokens that Intersight validates as OAuth2 bearer tokens. This supports:

- **Zero-trust deployments** — no static API keys stored in automation platforms
- **Sovereign cloud compliance** — short-lived credentials meet regulatory requirements
- **Secure AI factory infrastructure** — workload identity for automated provisioning

## Changes

- **`plugins/module_utils/intersight.py`**: Add `api_bearer_token` to `intersight_argument_spec`, branch `IntersightModule.__init__` to skip key loading for bearer auth, branch `intersight_call` to use Bearer authorization header
- **`plugins/doc_fragments/intersight.py`**: Document new `api_bearer_token` parameter with conditional requirement notes
- **`tests/unit/test_bearer_token_auth.py`**: 5 new unit tests covering bearer token auth path, validation, and backward compatibility
- **`tests/unit/test_v3_api_keys.py`**: Update existing test for new validation flow

## Usage

```yaml
# Bearer token auth (new)
- cisco.intersight.intersight_info:
    api_bearer_token: "{{ oauth2_token }}"
    server_names:
      - myserver

# Or via environment variable
# export INTERSIGHT_API_BEARER_TOKEN=<token>

# Existing key-based auth continues to work unchanged
- cisco.intersight.intersight_info:
    api_key_id: "{{ api_key_id }}"
    api_private_key: "{{ api_private_key }}"
    server_names:
      - myserver
```

## Backward Compatibility

- All existing playbooks using `api_key_id` + `api_private_key` work unchanged
- `api_key_id` and `api_private_key` are now conditionally required (only when `api_bearer_token` is not provided)
- Clear error messages guide users when neither auth method is configured
- Zero changes to any of the 131 module files — auth is fully centralized