### PR TITLE
feat: add intersight_server_profile_derive module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cisco.intersight Ansible Collection Changelog
 
+## Version 2.20.0
+- New intersight_server_profile_derive module for deriving profiles from templates (MoCloner) and syncing back (MoMerger).
+- Supports derive, sync, force_sync, delete, check-mode, and idempotency.
+
 ## Version 2.19.0
 - Added OAuth2 bearer token support for API authentication.
 - BIOS policy and CI fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Version 2.20.0
 - New intersight_server_profile_derive module for deriving profiles from templates (MoCloner) and syncing back (MoMerger).
-- Supports derive, sync, force_sync, delete, check-mode, and idempotency.
+  - Supports derive, sync, force_sync, delete, check-mode, and idempotency.
+- New intersight_pool_reservation module for managing pool identifier reservations (IP, UUID, MAC, WWNN, WWPN).
+  - Handles Intersight reservation API one-time-use constraint with pre-flight idempotency checks.
+  - Supports static and dynamic allocation, reserve and release operations.
 
 ## Version 2.19.0
 - Added OAuth2 bearer token support for API authentication.

--- a/plugins/modules/intersight_server_profile_derive.py
+++ b/plugins/modules/intersight_server_profile_derive.py
@@ -1,0 +1,294 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: intersight_server_profile_derive
+short_description: Derive Server Profiles from Templates in Cisco Intersight
+description:
+  - Derive new Server Profiles from a Server Profile Template using the Intersight MoCloner API.
+  - Sync existing derived profiles back to their template when the template has changed using the MoMerger API.
+  - Idempotent - will not re-derive if the profile already exists, and will not sync if the profile is already in sync.
+  - For more information see L(Cisco Intersight,https://intersight.com/apidocs).
+extends_documentation_fragment: intersight
+options:
+  organization:
+    description:
+      - The name of the Organization this resource is assigned to.
+    type: str
+    default: default
+  template_name:
+    description:
+      - Name of the Server Profile Template to derive from.
+      - The template must exist in the specified organization.
+    type: str
+    required: true
+  profile_names:
+    description:
+      - List of Server Profile names to derive from the template.
+      - Each name must be unique within the organization.
+    type: list
+    elements: str
+    required: true
+  state:
+    description:
+      - If C(present), will derive profiles that do not exist and sync profiles that are out of sync with the template.
+      - If C(absent), will delete derived profiles.
+    type: str
+    choices: [present, absent]
+    default: present
+  force_sync:
+    description:
+      - When C(true), always sync existing derived profiles to the template, even if the profile appears to be in sync.
+      - When C(false), only sync profiles whose ConfigContext shows they are out of sync with the template.
+    type: bool
+    default: false
+author:
+  - Steve Fulmer (@stevefulme1)
+'''
+
+EXAMPLES = r'''
+- name: Derive a single server profile from a template
+  cisco.intersight.intersight_server_profile_derive:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: default
+    template_name: My-Standard-Template
+    profile_names:
+      - SP-Derived-1
+
+- name: Derive multiple server profiles from a template
+  cisco.intersight.intersight_server_profile_derive:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    organization: default
+    template_name: My-Standard-Template
+    profile_names:
+      - SP-Derived-1
+      - SP-Derived-2
+      - SP-Derived-3
+
+- name: Force sync derived profiles back to template
+  cisco.intersight.intersight_server_profile_derive:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    template_name: My-Standard-Template
+    profile_names:
+      - SP-Derived-1
+    force_sync: true
+
+- name: Delete derived server profiles
+  cisco.intersight.intersight_server_profile_derive:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    template_name: My-Standard-Template
+    profile_names:
+      - SP-Derived-1
+    state: absent
+'''
+
+RETURN = r'''
+api_response:
+  description: Summary of derive/sync operations performed.
+  returned: always
+  type: dict
+  sample:
+    "api_response": {
+        "derived": ["SP-Derived-1", "SP-Derived-2"],
+        "synced": ["SP-Derived-3"],
+        "skipped": [],
+        "deleted": []
+    }
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
+
+
+def get_profile_by_name(intersight, profile_name):
+    """Look up a server profile by name."""
+    options = {
+        'http_method': 'get',
+        'resource_path': '/server/Profiles',
+        'query_params': {
+            '$filter': "Name eq '" + profile_name + "'",
+        },
+    }
+    response = intersight.call_api(**options)
+    if response.get('Results'):
+        return response['Results'][0]
+    return None
+
+
+def get_template_moid(intersight, template_name, organization_moid):
+    """Look up a server profile template by name and org."""
+    options = {
+        'http_method': 'get',
+        'resource_path': '/server/ProfileTemplates',
+        'query_params': {
+            '$filter': "Name eq '" + template_name + "' and Organization.Moid eq '" + organization_moid + "'",
+        },
+    }
+    response = intersight.call_api(**options)
+    if response.get('Results'):
+        return response['Results'][0]['Moid']
+    return None
+
+
+def derive_profile(intersight, template_moid, profile_name, organization_moid):
+    """Derive a new server profile from a template using MoCloner."""
+    options = {
+        'http_method': 'post',
+        'resource_path': '/bulk/MoCloners',
+        'body': {
+            'Sources': [
+                {
+                    'ClassId': 'mo.MoRef',
+                    'ObjectType': 'server.ProfileTemplate',
+                    'Moid': template_moid,
+                }
+            ],
+            'Targets': [
+                {
+                    'Name': profile_name,
+                    'ObjectType': 'server.Profile',
+                    'ClassId': 'server.Profile',
+                    'Organization': {
+                        'Moid': organization_moid,
+                    },
+                }
+            ],
+        },
+    }
+    return intersight.call_api(**options)
+
+
+def sync_profile(intersight, template_moid, profile_moid):
+    """Sync a derived profile back to its template using MoMerger."""
+    options = {
+        'http_method': 'post',
+        'resource_path': '/bulk/MoMergers',
+        'body': {
+            'Sources': [
+                {
+                    'ObjectType': 'server.ProfileTemplate',
+                    'Moid': template_moid,
+                }
+            ],
+            'Targets': [
+                {
+                    'ObjectType': 'server.Profile',
+                    'Moid': profile_moid,
+                }
+            ],
+            'MergeAction': 'Replace',
+        },
+    }
+    return intersight.call_api(**options)
+
+
+def delete_profile(intersight, profile_moid):
+    """Delete a server profile by Moid."""
+    options = {
+        'http_method': 'delete',
+        'resource_path': '/server/Profiles',
+        'moid': profile_moid,
+    }
+    return intersight.call_api(**options)
+
+
+def profile_needs_sync(profile, force_sync):
+    """Check if a derived profile needs syncing."""
+    if force_sync:
+        return True
+    config_context = profile.get('ConfigContext', {})
+    config_state = config_context.get('ConfigState', '')
+    return config_state in ('Pending-changes', 'Out-of-sync', 'Inconsistent')
+
+
+def main():
+    argument_spec = intersight_argument_spec.copy()
+    argument_spec.update(
+        organization=dict(type='str', default='default'),
+        template_name=dict(type='str', required=True),
+        profile_names=dict(type='list', elements='str', required=True),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        force_sync=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    intersight = IntersightModule(module)
+    intersight.result['api_response'] = {}
+    intersight.result['trace_id'] = ''
+
+    organization_name = module.params['organization']
+    template_name = module.params['template_name']
+    profile_names = module.params['profile_names']
+    state = module.params['state']
+    force_sync = module.params['force_sync']
+
+    organization_moid = intersight.get_moid_by_name(
+        resource_path='/organization/Organizations',
+        resource_name=organization_name,
+    )
+    if not organization_moid:
+        module.fail_json(msg="Organization '%s' not found." % organization_name)
+
+    template_moid = get_template_moid(intersight, template_name, organization_moid)
+    if not template_moid:
+        module.fail_json(msg="Server Profile Template '%s' not found in organization '%s'." % (template_name, organization_name))
+
+    result_summary = {
+        'derived': [],
+        'synced': [],
+        'skipped': [],
+        'deleted': [],
+    }
+
+    for profile_name in profile_names:
+        existing_profile = get_profile_by_name(intersight, profile_name)
+
+        if state == 'absent':
+            if existing_profile:
+                if not module.check_mode:
+                    delete_profile(intersight, existing_profile['Moid'])
+                result_summary['deleted'].append(profile_name)
+                intersight.result['changed'] = True
+            else:
+                result_summary['skipped'].append(profile_name)
+            continue
+
+        if existing_profile:
+            if profile_needs_sync(existing_profile, force_sync):
+                if not module.check_mode:
+                    sync_profile(intersight, template_moid, existing_profile['Moid'])
+                result_summary['synced'].append(profile_name)
+                intersight.result['changed'] = True
+            else:
+                result_summary['skipped'].append(profile_name)
+        else:
+            if not module.check_mode:
+                derive_profile(intersight, template_moid, profile_name, organization_moid)
+            result_summary['derived'].append(profile_name)
+            intersight.result['changed'] = True
+
+    intersight.result['api_response'] = result_summary
+    module.exit_json(**intersight.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intersight_server_profile_derive.py
+++ b/plugins/modules/intersight_server_profile_derive.py
@@ -248,16 +248,18 @@ def main():
     if not organization_moid:
         module.fail_json(msg="Organization '%s' not found." % organization_name)
 
-    template_moid = get_template_moid(intersight, template_name, organization_moid)
-    if not template_moid:
-        module.fail_json(msg="Server Profile Template '%s' not found in organization '%s'." % (template_name, organization_name))
-
     result_summary = {
         'derived': [],
         'synced': [],
         'skipped': [],
         'deleted': [],
     }
+
+    template_moid = None
+    if state == 'present':
+        template_moid = get_template_moid(intersight, template_name, organization_moid)
+        if not template_moid:
+            module.fail_json(msg="Server Profile Template '%s' not found in organization '%s'." % (template_name, organization_name))
 
     for profile_name in profile_names:
         existing_profile = get_profile_by_name(intersight, profile_name)

--- a/tests/integration/targets/intersight_server_profile_derive/defaults/main.yml
+++ b/tests/integration/targets/intersight_server_profile_derive/defaults/main.yml
@@ -1,0 +1,3 @@
+api_key_id: "{{ lookup('env', 'INTERSIGHT_API_KEY_ID_CI') }}"
+api_private_key: "{{ lookup('env', 'INTERSIGHT_API_PRIVATE_KEY_CI') }}"
+organization: "Demo-DevNet"

--- a/tests/integration/targets/intersight_server_profile_derive/meta/main.yml
+++ b/tests/integration/targets/intersight_server_profile_derive/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_run

--- a/tests/integration/targets/intersight_server_profile_derive/tasks/main.yml
+++ b/tests/integration/targets/intersight_server_profile_derive/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Import server profile derive tests
+  ansible.builtin.import_tasks: tests.yml

--- a/tests/integration/targets/intersight_server_profile_derive/tasks/tests.yml
+++ b/tests/integration/targets/intersight_server_profile_derive/tasks/tests.yml
@@ -32,7 +32,7 @@
     cisco.intersight.intersight_server_profile_template:
       <<: *api_info
       name: test_derive_template
-      target_platform: Standalone
+      target_platform: standalone
       description: "Template for derive integration tests"
     register: template_res
 

--- a/tests/integration/targets/intersight_server_profile_derive/tasks/tests.yml
+++ b/tests/integration/targets/intersight_server_profile_derive/tasks/tests.yml
@@ -1,0 +1,157 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  # --- Cleanup ---
+  - name: Clean up test profiles
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+        - test_derive_profile_2
+      state: absent
+    ignore_errors: true
+
+  - name: Clean up test template
+    cisco.intersight.intersight_server_profile_template:
+      <<: *api_info
+      name: test_derive_template
+      state: absent
+    ignore_errors: true
+
+  # --- Setup: Create a template ---
+  - name: Create Server Profile Template for derive tests
+    cisco.intersight.intersight_server_profile_template:
+      <<: *api_info
+      name: test_derive_template
+      target_platform: Standalone
+      description: "Template for derive integration tests"
+    register: template_res
+
+  - name: Verify template created
+    ansible.builtin.assert:
+      that:
+        - template_res is changed
+
+  # --- Test: Derive profile (check-mode) ---
+  - name: Derive profile - check-mode
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+    check_mode: true
+    register: derive_check_res
+
+  - name: Verify check-mode reports changed
+    ansible.builtin.assert:
+      that:
+        - derive_check_res is changed
+        - "'test_derive_profile_1' in derive_check_res.api_response.derived"
+
+  # --- Test: Derive profile ---
+  - name: Derive profile from template
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+    register: derive_res
+
+  - name: Verify derive succeeded
+    ansible.builtin.assert:
+      that:
+        - derive_res is changed
+        - "'test_derive_profile_1' in derive_res.api_response.derived"
+
+  # --- Test: Idempotency ---
+  - name: Derive same profile again (idempotency)
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+    register: idem_res
+
+  - name: Verify idempotency
+    ansible.builtin.assert:
+      that:
+        - idem_res is not changed
+        - "'test_derive_profile_1' in idem_res.api_response.skipped"
+
+  # --- Test: Derive multiple ---
+  - name: Derive multiple profiles
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+        - test_derive_profile_2
+    register: multi_res
+
+  - name: Verify mixed derive (one skipped, one derived)
+    ansible.builtin.assert:
+      that:
+        - multi_res is changed
+        - "'test_derive_profile_1' in multi_res.api_response.skipped"
+        - "'test_derive_profile_2' in multi_res.api_response.derived"
+
+  # --- Test: Force sync ---
+  - name: Force sync profiles
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+      force_sync: true
+    register: sync_res
+
+  - name: Verify sync happened
+    ansible.builtin.assert:
+      that:
+        - sync_res is changed
+        - "'test_derive_profile_1' in sync_res.api_response.synced"
+
+  # --- Test: Delete ---
+  - name: Delete derived profiles
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+        - test_derive_profile_2
+      state: absent
+    register: delete_res
+
+  - name: Verify deletion
+    ansible.builtin.assert:
+      that:
+        - delete_res is changed
+        - "'test_derive_profile_1' in delete_res.api_response.deleted"
+        - "'test_derive_profile_2' in delete_res.api_response.deleted"
+
+  always:
+  - name: Final cleanup - profiles
+    cisco.intersight.intersight_server_profile_derive:
+      <<: *api_info
+      template_name: test_derive_template
+      profile_names:
+        - test_derive_profile_1
+        - test_derive_profile_2
+      state: absent
+    ignore_errors: true
+
+  - name: Final cleanup - template
+    cisco.intersight.intersight_server_profile_template:
+      <<: *api_info
+      name: test_derive_template
+      state: absent
+    ignore_errors: true

--- a/tests/unit/test_server_profile_derive.py
+++ b/tests/unit/test_server_profile_derive.py
@@ -1,0 +1,148 @@
+import unittest
+from unittest.mock import MagicMock
+
+from ansible_collections.cisco.intersight.plugins.modules.intersight_server_profile_derive import (
+    get_profile_by_name,
+    get_template_moid,
+    derive_profile,
+    sync_profile,
+    delete_profile,
+    profile_needs_sync,
+)
+
+
+class FailJsonException(Exception):
+    pass
+
+
+def make_intersight_mock(check_mode=False):
+    module = MagicMock()
+    module.check_mode = check_mode
+    module.params = {}
+    module.fail_json.side_effect = FailJsonException
+    intersight = MagicMock()
+    intersight.module = module
+    intersight.result = {'changed': False, 'api_response': {}}
+    return intersight
+
+
+def make_profile(name='test-profile', moid='profile-123', config_state='Associated'):
+    return {
+        'Moid': moid,
+        'Name': name,
+        'ConfigContext': {
+            'ControlAction': 'No-op',
+            'ConfigState': config_state,
+            'OperState': 'Ok',
+        },
+    }
+
+
+class TestGetProfileByName(unittest.TestCase):
+    def test_returns_profile_when_found(self):
+        intersight = make_intersight_mock()
+        profile = make_profile()
+        intersight.call_api.return_value = {'Results': [profile]}
+
+        result = get_profile_by_name(intersight, 'test-profile')
+
+        self.assertEqual(result['Moid'], 'profile-123')
+
+    def test_returns_none_when_not_found(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {'Results': []}
+
+        result = get_profile_by_name(intersight, 'nonexistent')
+
+        self.assertIsNone(result)
+
+
+class TestGetTemplateMoid(unittest.TestCase):
+    def test_returns_moid_when_found(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {'Results': [{'Moid': 'template-abc'}]}
+
+        result = get_template_moid(intersight, 'My-Template', 'org-123')
+
+        self.assertEqual(result, 'template-abc')
+
+    def test_returns_none_when_not_found(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {'Results': []}
+
+        result = get_template_moid(intersight, 'Bad-Template', 'org-123')
+
+        self.assertIsNone(result)
+
+
+class TestDeriveProfile(unittest.TestCase):
+    def test_posts_mocloner(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {'Moid': 'cloner-123'}
+
+        derive_profile(intersight, 'template-abc', 'SP-Derived-1', 'org-123')
+
+        call_args = intersight.call_api.call_args
+        self.assertEqual(call_args.kwargs['http_method'], 'post')
+        self.assertEqual(call_args.kwargs['resource_path'], '/bulk/MoCloners')
+        body = call_args.kwargs['body']
+        self.assertEqual(body['Sources'][0]['Moid'], 'template-abc')
+        self.assertEqual(body['Targets'][0]['Name'], 'SP-Derived-1')
+
+
+class TestSyncProfile(unittest.TestCase):
+    def test_posts_momerger(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {}
+
+        sync_profile(intersight, 'template-abc', 'profile-123')
+
+        call_args = intersight.call_api.call_args
+        self.assertEqual(call_args.kwargs['http_method'], 'post')
+        self.assertEqual(call_args.kwargs['resource_path'], '/bulk/MoMergers')
+        body = call_args.kwargs['body']
+        self.assertEqual(body['MergeAction'], 'Replace')
+        self.assertEqual(body['Sources'][0]['Moid'], 'template-abc')
+        self.assertEqual(body['Targets'][0]['Moid'], 'profile-123')
+
+
+class TestDeleteProfile(unittest.TestCase):
+    def test_deletes_by_moid(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {}
+
+        delete_profile(intersight, 'profile-123')
+
+        call_args = intersight.call_api.call_args
+        self.assertEqual(call_args.kwargs['http_method'], 'delete')
+        self.assertEqual(call_args.kwargs['moid'], 'profile-123')
+
+
+class TestProfileNeedsSync(unittest.TestCase):
+    def test_force_sync_always_true(self):
+        profile = make_profile(config_state='Associated')
+        self.assertTrue(profile_needs_sync(profile, force_sync=True))
+
+    def test_pending_changes_needs_sync(self):
+        profile = make_profile(config_state='Pending-changes')
+        self.assertTrue(profile_needs_sync(profile, force_sync=False))
+
+    def test_out_of_sync_needs_sync(self):
+        profile = make_profile(config_state='Out-of-sync')
+        self.assertTrue(profile_needs_sync(profile, force_sync=False))
+
+    def test_inconsistent_needs_sync(self):
+        profile = make_profile(config_state='Inconsistent')
+        self.assertTrue(profile_needs_sync(profile, force_sync=False))
+
+    def test_associated_no_sync(self):
+        profile = make_profile(config_state='Associated')
+        self.assertFalse(profile_needs_sync(profile, force_sync=False))
+
+    def test_assigned_no_sync(self):
+        profile = make_profile(config_state='Assigned')
+        self.assertFalse(profile_needs_sync(profile, force_sync=False))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_server_profile_derive.py
+++ b/tests/unit/test_server_profile_derive.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from ansible_collections.cisco.intersight.plugins.modules import intersight_server_profile_derive as derive_module
 from ansible_collections.cisco.intersight.plugins.modules.intersight_server_profile_derive import (
     get_profile_by_name,
     get_template_moid,
@@ -12,6 +13,10 @@ from ansible_collections.cisco.intersight.plugins.modules.intersight_server_prof
 
 
 class FailJsonException(Exception):
+    pass
+
+
+class ExitJsonException(Exception):
     pass
 
 
@@ -142,6 +147,80 @@ class TestProfileNeedsSync(unittest.TestCase):
     def test_assigned_no_sync(self):
         profile = make_profile(config_state='Assigned')
         self.assertFalse(profile_needs_sync(profile, force_sync=False))
+
+
+class TestMain(unittest.TestCase):
+    @patch.object(derive_module, 'get_template_moid')
+    @patch.object(derive_module, 'get_profile_by_name')
+    @patch.object(derive_module, 'IntersightModule')
+    @patch.object(derive_module, 'AnsibleModule')
+    def test_absent_does_not_require_template(
+        self,
+        ansible_module_mock,
+        intersight_module_mock,
+        get_profile_by_name_mock,
+        get_template_moid_mock,
+    ):
+        module = MagicMock()
+        module.check_mode = False
+        module.params = {
+            'organization': 'Demo-DevNet',
+            'template_name': 'missing-template',
+            'profile_names': ['test-profile'],
+            'state': 'absent',
+            'force_sync': False,
+        }
+        module.exit_json.side_effect = ExitJsonException
+        module.fail_json.side_effect = FailJsonException
+        ansible_module_mock.return_value = module
+
+        intersight = MagicMock()
+        intersight.result = {'changed': False, 'api_response': {}, 'trace_id': ''}
+        intersight.get_moid_by_name.return_value = 'org-123'
+        intersight_module_mock.return_value = intersight
+        get_profile_by_name_mock.return_value = None
+
+        with self.assertRaises(ExitJsonException):
+            derive_module.main()
+
+        get_template_moid_mock.assert_not_called()
+        module.fail_json.assert_not_called()
+        module.exit_json.assert_called_once()
+        result = module.exit_json.call_args.kwargs
+        self.assertFalse(result['changed'])
+        self.assertEqual(result['api_response']['skipped'], ['test-profile'])
+
+    @patch.object(derive_module, 'get_template_moid')
+    @patch.object(derive_module, 'IntersightModule')
+    @patch.object(derive_module, 'AnsibleModule')
+    def test_present_requires_template(
+        self,
+        ansible_module_mock,
+        intersight_module_mock,
+        get_template_moid_mock,
+    ):
+        module = MagicMock()
+        module.params = {
+            'organization': 'Demo-DevNet',
+            'template_name': 'missing-template',
+            'profile_names': ['test-profile'],
+            'state': 'present',
+            'force_sync': False,
+        }
+        module.fail_json.side_effect = FailJsonException
+        ansible_module_mock.return_value = module
+
+        intersight = MagicMock()
+        intersight.result = {'changed': False, 'api_response': {}, 'trace_id': ''}
+        intersight.get_moid_by_name.return_value = 'org-123'
+        intersight_module_mock.return_value = intersight
+        get_template_moid_mock.return_value = None
+
+        with self.assertRaises(FailJsonException):
+            derive_module.main()
+
+        get_template_moid_mock.assert_called_once_with(intersight, 'missing-template', 'org-123')
+        module.exit_json.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

New `intersight_server_profile_derive` module for deriving server profiles from templates and syncing existing derived profiles back to their template.

Replaces the manual `playbooks/derive_profiles.yml` workflow with a proper idempotent module.

## API Endpoints

| Operation | Endpoint | Description |
|-----------|----------|-------------|
| Derive | `POST /bulk/MoCloners` | Clone template → new profile |
| Sync | `POST /bulk/MoMergers` | Merge template changes → existing profile |
| Delete | `DELETE /server/Profiles/{Moid}` | Remove derived profile |

## Parameters

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `template_name` | str | yes | Template to derive from |
| `profile_names` | list | yes | Profiles to derive/sync |
| `organization` | str | no | Org name (default: `default`) |
| `state` | str | no | `present`/`absent` |
| `force_sync` | bool | no | Force sync even if in-sync |

## Usage

```yaml
- name: Derive profiles from template
  cisco.intersight.intersight_server_profile_derive:
    template_name: My-Standard-Template
    profile_names:
      - SP-Derived-1
      - SP-Derived-2

- name: Force sync after template change
  cisco.intersight.intersight_server_profile_derive:
    template_name: My-Standard-Template
    profile_names:
      - SP-Derived-1
    force_sync: true
```

## Idempotency

- Derive skips if profile already exists
- Sync skips if ConfigState is not Pending-changes/Out-of-sync/Inconsistent
- Delete skips if profile doesn't exist
- Full check-mode support

## Test plan

- [x] 13 unit tests covering derive, sync, delete, idempotency, force_sync
- [x] Integration test target with full lifecycle (create template → derive → idempotency → sync → delete → cleanup)
- [x] ansible-lint passes (production profile)
- [x] DOCUMENTATION YAML validates
- [ ] CI integration tests (require Intersight sandbox)