### PR TITLE
feat: add IQN pool reservation support

### DIFF
--- a/plugins/modules/intersight_pool_reservation.py
+++ b/plugins/modules/intersight_pool_reservation.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: intersight_pool_reservation
 short_description: Manage pool identifier reservations in Cisco Intersight
 description:
-  - Reserve and release identifiers (IP, UUID, MAC, WWNN, WWPN) from Intersight pools.
+  - Reserve and release identifiers (IP, UUID, MAC, IQN, WWNN, WWPN) from Intersight pools.
   - Handles the Intersight reservation API's one-time-use constraint by performing a pre-flight
     check before attempting to reserve, ensuring idempotent playbook runs.
   - Reserved identifiers are consumed when a policy using them is attached to a server profile
@@ -29,7 +29,7 @@ options:
       - The type of pool to manage reservations for.
     type: str
     required: true
-    choices: [ip, uuid, mac, wwnn, wwpn]
+    choices: [ip, uuid, mac, iqn, wwnn, wwpn]
   pool_name:
     description:
       - Name of the pool to reserve from.
@@ -42,7 +42,7 @@ options:
     default: default
   identity:
     description:
-      - The specific identifier value to reserve (e.g., an IP address, UUID, MAC address).
+      - The specific identifier value to reserve (e.g., an IP address, UUID, MAC address, IQN).
       - Required when C(state) is C(present).
     type: str
   state:
@@ -105,6 +105,14 @@ EXAMPLES = r'''
     pool_type: ip
     pool_name: IP-Pool-01
     allocation_type: dynamic
+
+- name: Reserve an IQN from a pool
+  cisco.intersight.intersight_pool_reservation:
+    api_private_key: "{{ api_private_key }}"
+    api_key_id: "{{ api_key_id }}"
+    pool_type: iqn
+    pool_name: IQN-Pool-01
+    identity: "iqn.2010-11.com.flexpod:storage:component:server01"
 '''
 
 RETURN = r'''
@@ -149,6 +157,12 @@ POOL_TYPE_MAP = {
         'pool_path': '/fcpool/Pools',
         'identity_key': 'Identity',
         'object_type': 'fcpool.Reservation',
+    },
+    'iqn': {
+        'resource_path': '/iqnpool/Reservations',
+        'pool_path': '/iqnpool/Pools',
+        'identity_key': 'Identity',
+        'object_type': 'iqnpool.Reservation',
     },
     'wwpn': {
         'resource_path': '/fcpool/Reservations',
@@ -238,7 +252,7 @@ def delete_reservation(intersight, resource_path, reservation_moid):
 def main():
     argument_spec = intersight_argument_spec.copy()
     argument_spec.update(
-        pool_type=dict(type='str', required=True, choices=['ip', 'uuid', 'mac', 'wwnn', 'wwpn']),
+        pool_type=dict(type='str', required=True, choices=['ip', 'uuid', 'mac', 'iqn', 'wwnn', 'wwpn']),
         pool_name=dict(type='str', required=True),
         organization=dict(type='str', default='default'),
         identity=dict(type='str'),

--- a/tests/integration/targets/intersight_iqn_pool_reservation/tasks/tests.yml
+++ b/tests/integration/targets/intersight_iqn_pool_reservation/tasks/tests.yml
@@ -1,0 +1,127 @@
+---
+- block:
+  - name: Define anchor for Intersight API login info
+    ansible.builtin.set_fact:
+      api_info: &api_info
+        api_private_key: "{{ api_private_key }}"
+        api_key_id: "{{ api_key_id }}"
+        api_uri: "{{ api_uri | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(omit) }}"
+        organization: "{{ organization }}"
+
+  # --- Setup: Create IQN pool ---
+  - name: Create IQN Pool for reservation tests
+    cisco.intersight.intersight_iqn_pool:
+      <<: *api_info
+      name: test_reservation_iqn_pool
+      description: "IQN pool for reservation integration tests"
+      prefix: "iqn.2010-11.com.flexpod"
+      iqn_suffix_blocks:
+        - suffix: "storage"
+          iqn_from: 1
+          size: 10
+    register: pool_res
+
+  - name: Verify pool created
+    ansible.builtin.assert:
+      that:
+        - pool_res is changed
+
+  - name: Ensure test reservation is absent
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+      state: absent
+
+  # --- Test: Reserve IQN (check-mode) ---
+  - name: Reserve IQN - check-mode
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+    check_mode: true
+    register: check_res
+
+  - name: Verify check-mode reports changed
+    ansible.builtin.assert:
+      that:
+        - check_res is changed
+
+  # --- Test: Reserve IQN ---
+  - name: Reserve specific IQN
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+    register: reserve_res
+
+  - name: Verify reservation
+    ansible.builtin.assert:
+      that:
+        - reserve_res is changed
+        - reserve_res.api_response is defined
+
+  # --- Test: Idempotency ---
+  - name: Reserve same IQN again (idempotency)
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+    register: idem_res
+
+  - name: Verify idempotency
+    ansible.builtin.assert:
+      that:
+        - idem_res is not changed
+
+  # --- Test: Release ---
+  - name: Release IQN reservation
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+      state: absent
+    register: release_res
+
+  - name: Verify release
+    ansible.builtin.assert:
+      that:
+        - release_res is changed
+
+  # --- Test: Release non-existent (idempotent) ---
+  - name: Release non-existent IQN reservation
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:99"
+      state: absent
+    register: noop_res
+
+  - name: Verify no-op
+    ansible.builtin.assert:
+      that:
+        - noop_res is not changed
+
+  always:
+  - name: Final cleanup - reservation
+    cisco.intersight.intersight_pool_reservation:
+      <<: *api_info
+      pool_type: iqn
+      pool_name: test_reservation_iqn_pool
+      identity: "iqn.2010-11.com.flexpod:storage:1"
+      state: absent
+    ignore_errors: true
+
+  - name: Final cleanup - pool
+    cisco.intersight.intersight_iqn_pool:
+      <<: *api_info
+      name: test_reservation_iqn_pool
+      state: absent
+    ignore_errors: true

--- a/tests/unit/test_pool_reservation.py
+++ b/tests/unit/test_pool_reservation.py
@@ -134,6 +134,22 @@ class TestCreateReservation(unittest.TestCase):
         self.assertEqual(body['IdPurpose'], 'WWPN')
 
 
+    def test_iqn_reservation(self):
+        intersight = make_intersight_mock()
+        intersight.call_api.return_value = {}
+
+        create_reservation(
+            intersight, '/iqnpool/Reservations', 'pool-123',
+            'org-123', 'iqn.2010-11.com.flexpod:storage:component:server01', 'static', 'iqnpool.Reservation', 'iqn',
+        )
+
+        call_args = intersight.call_api.call_args
+        body = call_args.kwargs['body']
+        self.assertEqual(body['Identity'], 'iqn.2010-11.com.flexpod:storage:component:server01')
+        self.assertEqual(body['ObjectType'], 'iqnpool.Reservation')
+        self.assertNotIn('IdPurpose', body)
+
+
 class TestDeleteReservation(unittest.TestCase):
     def test_deletes_by_moid(self):
         intersight = make_intersight_mock()
@@ -148,7 +164,7 @@ class TestDeleteReservation(unittest.TestCase):
 
 class TestPoolTypeMap(unittest.TestCase):
     def test_all_pool_types_mapped(self):
-        for pool_type in ['ip', 'uuid', 'mac', 'wwnn', 'wwpn']:
+        for pool_type in ['ip', 'uuid', 'mac', 'iqn', 'wwnn', 'wwpn']:
             self.assertIn(pool_type, POOL_TYPE_MAP)
             self.assertIn('resource_path', POOL_TYPE_MAP[pool_type])
             self.assertIn('pool_path', POOL_TYPE_MAP[pool_type])

--- a/tests/unit/test_pool_reservation.py
+++ b/tests/unit/test_pool_reservation.py
@@ -133,7 +133,6 @@ class TestCreateReservation(unittest.TestCase):
         body = call_args.kwargs['body']
         self.assertEqual(body['IdPurpose'], 'WWPN')
 
-
     def test_iqn_reservation(self):
         intersight = make_intersight_mock()
         intersight.call_api.return_value = {}


### PR DESCRIPTION
## Summary

- Add `iqn` pool type to `intersight_pool_reservation` module, targeting `/iqnpool/Reservations` and `/iqnpool/Pools` API endpoints
- IQN reservations follow the same idempotent pattern as existing pool types (IP, UUID, MAC, WWNN, WWPN)
- Includes unit test for IQN reservation body construction and full integration test target

## Test plan

- [ ] Unit test: `test_iqn_reservation` validates POST body has correct `ObjectType: iqnpool.Reservation`, `Identity`, and no `IdPurpose`
- [ ] Unit test: `test_all_pool_types_mapped` verifies all 6 pool types present in `POOL_TYPE_MAP`
- [ ] Integration test: reserve/idempotency/release/no-op cycle against IQN pool (mirrors existing IP pool test structure)

Ref: ACA-4997