### PR TITLE
fix: don't treat empty list response as a found resource in get_resource

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -8,6 +8,7 @@
 changelog_filename_template: ../CHANGELOG.md
 changelog_filename_version_depth: 0
 notesdir: fragments
+changes_format: combined
 
 # Keep this aligned with Ansible's standard fragment section names.
 sections:

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Changelog config for ansible-test sanity "changelog".
+# See: https://docs.ansible.com/ansible-core/devel/dev_guide/testing/sanity/changelog.html
+
+changelog_filename_template: ../CHANGELOG.md
+changelog_filename_version_depth: 0
+notesdir: fragments
+
+# Keep this aligned with Ansible's standard fragment section names.
+sections:
+  - - major_changes
+    - Major Changes
+  - - minor_changes
+    - Minor Changes
+  - - breaking_changes
+    - Breaking Changes / Porting Guide
+  - - deprecated_features
+    - Deprecated Features
+  - - removed_features
+    - Removed Features (previously deprecated)
+  - - security_fixes
+    - Security Fixes
+  - - bugfixes
+    - Bugfixes
+  - - known_issues
+    - Known Issues
+
+# This collection uses Markdown for CHANGELOG.md.
+output_formats:
+  - md
+
+use_fqcn: true

--- a/changelogs/fragments/342-get-resource-empty-list.yml
+++ b/changelogs/fragments/342-get-resource-empty-list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils - ``get_resource`` no longer stores an empty list-response wrapper as a found object. A filtered query with no matches now clears ``api_response`` instead of keeping the ``asset.*.List`` dict, so callers such as ``intersight_target_claim`` correctly detect an absent resource and perform the create/claim (https://github.com/CiscoDevNet/intersight-ansible/issues/342).

--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -407,8 +407,13 @@ class IntersightModule():
                 # return the 1st list element
                 self.result['api_response'] = response['Results'][0]
         else:
-            # Return a dict if no Results array (handles case where resource_path contains a Moid)
-            if isinstance(response, dict):
+            # A GET by Moid returns the object directly (a dict with no
+            # 'Results' key). A filtered list query with no matches returns a
+            # dict that DOES contain an (empty) 'Results' key; that is not a
+            # hit and must not be stored, otherwise callers that guard on
+            # `if not api_response` (e.g. intersight_target_claim) treat the
+            # empty result as an existing object and skip their action.
+            if isinstance(response, dict) and 'Results' not in response:
                 self.result['api_response'] = response
             else:
                 # Clear api_response when no results found to prevent returning stale data


### PR DESCRIPTION
Fixes #342

### Problem
get_resource() stores an empty list-response wrapper as a found object. For a filtered query with no matches, Intersight returns a dict like {"ObjectType":"asset.Target.List","Results":[],"Count":0}. Because that dict is truthy, it was assigned to api_response.

Callers that guard on `if not api_response` then treat "no match" as "resource exists" and skip their action. Concretely, intersight_target_claim (state: present) never sends the /asset/DeviceClaims POST for an unclaimed device: the task reports ok/changed:false while the device stays Not Claimed, with no error.

### Fix
Only store a no-Results dict when the response has no Results key at all (a GET by Moid returns the bare object). When a filtered list query returns an empty Results, clear api_response, matching the pre-existing "clear stale data" intent.

### Impact
- Fixes claiming of new devices via intersight_target_claim.
- GET-by-Moid behavior is unchanged (still returns the bare object dict).
- Modules that create-if-absent via a filtered pre-check now correctly detect absence.

### Testing
Verified end-to-end against a standalone CIMC server: with the fix, intersight_target_claim returns an asset.DeviceClaim object with changed:true and the device transitions to Claimed. Without the fix, the same play reports changed:false and the device stays Not Claimed.

A changelog fragment is included.