### PR TITLE
Harden ansible test safe-to-test flow

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,4 +1,3 @@
----
 name: Ansible-test CI
 on:
   workflow_dispatch:
@@ -18,6 +17,8 @@ on:
     branches:
       - stable-ci
   pull_request_target:
+    types:
+      - labeled
     branches:
       - main
       - 'stable-*'
@@ -35,99 +36,46 @@ permissions:
 jobs:
   detect-changes:
     name: Detect Changed Files
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.label.name == 'safe to test'
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.map-tests.outputs.targets }}
       skip_tests: ${{ steps.map-tests.outputs.skip_tests }}
     steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout code
-        if: steps.checkAccess.outputs.require-result == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0  # Fetch full history for comparison
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Map changed files to test targets
-        if: steps.checkAccess.outputs.require-result == 'true'
         id: map-tests
         env:
           RUN_ALL_TESTS: ${{ github.event.inputs.run_all_tests }}
+        shell: bash
         run: |
-          # For weekly regression (scheduled) or manual all-tests run, force run all integration tests
+          # For weekly regression (scheduled) or manual all-tests run, force all integration tests.
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.run_all_tests }}" == "true" ]]; then
-            echo "targets=" >> $GITHUB_OUTPUT
-            echo "skip_tests=false" >> $GITHUB_OUTPUT
-            echo "Running weekly regression - all integration tests will be executed"
+            echo "targets=" >> "$GITHUB_OUTPUT"
+            echo "skip_tests=false" >> "$GITHUB_OUTPUT"
+            echo "Running all integration tests"
           else
             python3 .github/workflows/scripts/map_changes_to_tests.py
           fi
-  units:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        ansible:
-          - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          - stable-2.19
-          - stable-2.20
-          - stable-2.21
-    steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Run integration tests inside a Docker container.
-      # The docker container has all the pinned dependencies that are
-      # required and all Python versions Ansible supports.
-      - name: Perform unit testing
-        id: unit-test
-        # See the documentation for the following GitHub action on
-        # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@release/v1
-        with:
-          ansible-core-version: ${{ matrix.ansible }}
-          testing-type: units
-          git-checkout-ref: ${{ github.event.pull_request.head.sha }}
-      - name: Record unit test result
-        id: test-results
-        if: always()
-        run: |
-          TEST_TYPE="Unit Tests"
-          if [ "${{ steps.unit-test.outcome }}" = "success" ]; then
-            echo "$TEST_TYPE test for ${{ matrix.ansible }}: ✅ PASSED" >> $GITHUB_STEP_SUMMARY
-            echo "results=${{ matrix.ansible }}:success" >> $GITHUB_OUTPUT
-          else
-            echo "$TEST_TYPE test for ${{ matrix.ansible }}: ❌ FAILED" >> $GITHUB_STEP_SUMMARY
-            echo "results=${{ matrix.ansible }}:failure" >> $GITHUB_OUTPUT
-            echo "$TEST_TYPE test failed for ${{ matrix.ansible }}" >&2
-          fi
+
   integration:
     name: >-
-      ${{ (github.event_name == 'schedule' || github.event.inputs.run_all_tests == 'true') && 
+      ${{ (github.event_name == 'schedule' || github.event.inputs.run_all_tests == 'true') &&
       'Weekly Regression Integration (Ⓐ' || 'Integration (Ⓐ' }}${{ matrix.ansible }})
     runs-on: >-
       ${{ contains(fromJson(
           '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     needs: detect-changes
-    if: needs.detect-changes.outputs.skip_tests != 'true'
+    if: >-
+      needs.detect-changes.outputs.skip_tests != 'true'
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -141,30 +89,24 @@ jobs:
     outputs:
       results: ${{ steps.test-results.outputs.results }}
     steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
       # Run integration tests inside a Docker container.
       # The docker container has all the pinned dependencies that are
       # required and all Python versions Ansible supports.
       - name: Perform integration testing
-        if: steps.checkAccess.outputs.require-result == 'true'
         id: integration-test
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3 # release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: integration
           target: ${{ needs.detect-changes.outputs.targets }}
-          pre-test-cmd: chmod +x ./tests/integration/targets/prepare_test_run/generate_integration_config.sh && ./tests/integration/targets/prepare_test_run/generate_integration_config.sh
-          git-checkout-ref: ${{ github.event.pull_request.head.sha }}
+          pre-test-cmd: >-
+            install -d ./tests/integration/targets/prepare_test_run
+            && printf '%s\n' "$API_PRIVATE_KEY" > ./tests/integration/targets/prepare_test_run/api_private_key.pem
+            && chmod 600 ./tests/integration/targets/prepare_test_run/api_private_key.pem
+            && printf '%s\n' '---' 'api_private_key: ./targets/prepare_test_run/api_private_key.pem' "api_key_id: ${API_KEY_ID}" > ./tests/integration/targets/prepare_test_run/integration_config.yml
+          git-checkout-ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         env:
           API_PRIVATE_KEY: ${{ secrets.INTERSIGHT_API_PRIVATE_KEY_CI }}
           API_KEY_ID: ${{ secrets.INTERSIGHT_API_KEY_ID_CI }}
@@ -194,14 +136,15 @@ jobs:
           echo "Integration tests skipped - no relevant changes detected"
           echo "This job automatically succeeds to satisfy branch protection rules"
 
-
   final_check: # This job does nothing and is only used for the branch protection
     # or multi-stage CI jobs, like making sure that all tests pass before
     # a publishing job is started.
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request_target' ||
+      github.event.label.name == 'safe to test')
 
     needs:
-      - units
       - detect-changes
       - integration
       - integration-skipped
@@ -210,7 +153,7 @@ jobs:
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           # Allow skipping integration jobs when no changes detected
           allowed-skips: integration, integration-skipped

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Perform sanity testing
         # See the documentation for the following GitHub action on
         # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3 # release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
@@ -116,6 +116,37 @@ jobs:
           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
           pull-request-change-detection: false
 
+  units:
+    name: Units (Ⓐ${{ matrix.ansible }})
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        ansible:
+          - stable-2.16
+          - stable-2.17
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
+          - stable-2.21
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    steps:
+      - name: Perform unit testing
+        # See the documentation for the following GitHub action on
+        # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3 # release/v1
+        with:
+          ansible-core-version: ${{ matrix.ansible }}
+          testing-type: units
+
   check:  # This job does nothing and is only used for the branch protection
           # or multi-stage CI jobs, like making sure that all tests pass before
           # a publishing job is started.
@@ -123,11 +154,12 @@ jobs:
 
     needs:
       - sanity
+      - units
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
#### SUMMARY
- split unit tests into the untrusted CI workflow so ordinary PRs run without privileged `pull_request_target` execution
- gate privileged integration runs on the `safe to test` label and keep PR head checkout behind that approval step
- pin third-party action references and inline integration config generation for the secret-bearing job

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- .github/workflows/ansible-test.yml
- .github/workflows/main.yml

#### ADDITIONAL INFORMATION
- validated the updated workflow YAML locally with `yaml.safe_load`
- pinned `actions/checkout`, `ansible-community/ansible-test-gh-action`, and `re-actors/alls-green` to commit SHAs