### PR TITLE
chore: add dummy comment for ansible-test ci validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,5 @@ Cisco's DevNet includes a [Learning Lab on using this collection](https://develo
 ## License Information
 
 Licensed under the [MIT License](https://github.com/CiscoDevNet/intersight-ansible/blob/main/LICENSE.txt).
+
+<!-- Dummy change to verify CI skips integration tests for README-only PRs. -->

--- a/plugins/modules/intersight_ntp_policy_info.py
+++ b/plugins/modules/intersight_ntp_policy_info.py
@@ -3,8 +3,6 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Dummy change to exercise ansible-test CI change detection (round 3).
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/intersight_ntp_policy_info.py
+++ b/plugins/modules/intersight_ntp_policy_info.py
@@ -3,6 +3,8 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# Dummy change to exercise ansible-test CI change detection.
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/intersight_ntp_policy_info.py
+++ b/plugins/modules/intersight_ntp_policy_info.py
@@ -3,7 +3,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Dummy change to exercise ansible-test CI change detection.
+# Dummy change to exercise ansible-test CI change detection (round 2).
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/modules/intersight_ntp_policy_info.py
+++ b/plugins/modules/intersight_ntp_policy_info.py
@@ -3,7 +3,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Dummy change to exercise ansible-test CI change detection (round 2).
+# Dummy change to exercise ansible-test CI change detection (round 3).
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type


### PR DESCRIPTION
#### SUMMARY
- Add a no-op comment in `intersight_ntp_policy_info` to exercise the hardened ansible-test CI change-detection and safe-to-test flow.

#### ISSUE TYPE
- Refactoring Pull Request

#### COMPONENT NAME
- plugins/modules/intersight_ntp_policy_info.py

#### ADDITIONAL INFORMATION
- Temporary validation PR; safe to close/revert after CI verification.
- Apply the `safe to test` label to trigger integration tests.