### PR TITLE
Use temp checkout source for ansible-test CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -97,6 +97,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
+          path: .tmp-ansible-collection-source
 
       # Run integration tests inside a Docker container.
       # The docker container has all the pinned dependencies that are
@@ -110,7 +111,7 @@ jobs:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: integration
           target: ${{ needs.detect-changes.outputs.targets }}
-          collection-src-directory: .
+          collection-src-directory: .tmp-ansible-collection-source
           pre-test-cmd: >-
             install -d ./tests/integration/targets/prepare_test_run
             && printf '%s\n' "$API_PRIVATE_KEY" > ./tests/integration/targets/prepare_test_run/api_private_key.pem


### PR DESCRIPTION
#### SUMMARY
- fix the follow-up ansible-test CI failure caused by `collection-src-directory: .` copying the workspace into `ansible_collections/cisco/intersight`
- check out the PR source into `.tmp-ansible-collection-source` before invoking `ansible-test-gh-action`
- point `collection-src-directory` at that temp checkout so the action copies from an external source path instead of recursively copying the repo into itself

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- .github/workflows/ansible-test.yml

#### ADDITIONAL INFORMATION
- this keeps the explicit unsafe-checkout workaround from the previous change, but avoids the self-copy error shown on PR #345
- no GitHub Actions run was executed locally; the expected validation is rerunning the labeled fork PR after this workflow update merges